### PR TITLE
Qualify and resolve expression columns correctly

### DIFF
--- a/src/Compat/FilterProcessor.php
+++ b/src/Compat/FilterProcessor.php
@@ -272,10 +272,9 @@ class FilterProcessor extends \ipl\Sql\Compat\FilterProcessor
                         $targetKeys = join(
                             ',',
                             array_values(
-                                $subQuery->getResolver()->qualifyColumnsAndAliases(
+                                $subQuery->getResolver()->qualifyColumns(
                                     (array) $subQuery->getModel()->getKeyName(),
-                                    $subQuery->getModel(),
-                                    false
+                                    $subQuery->getModel()
                                 )
                             )
                         );

--- a/src/Query.php
+++ b/src/Query.php
@@ -336,10 +336,10 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
         if (empty($columns) || $allColumns) {
             $select->columns(
                 $resolver->qualifyColumnsAndAliases(
-                    $allColumns
+                    $resolver->requireAndResolveColumns($allColumns
                         ? $resolver->requireRemainingColumns($select->getColumns(), $model)
-                        : $resolver->getSelectColumns($model),
-                    $model,
+                        : $resolver->getSelectColumns($model)),
+                    null,
                     false
                 )
             );
@@ -347,10 +347,12 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
             foreach ($this->getWith() as $relation) {
                 $select->columns(
                     $resolver->qualifyColumnsAndAliases(
-                        $allColumns
-                            ? $resolver->requireRemainingColumns($select->getColumns(), $relation->getTarget())
-                            : $resolver->getSelectColumns($relation->getTarget()),
-                        $relation->getTarget()
+                        $resolver->requireAndResolveColumns(
+                            $allColumns
+                                ? $resolver->requireRemainingColumns($select->getColumns(), $relation->getTarget())
+                                : $resolver->getSelectColumns($relation->getTarget()),
+                            $relation->getTarget()
+                        )
                     )
                 );
             }

--- a/src/ResolvedExpression.php
+++ b/src/ResolvedExpression.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace ipl\Orm;
+
+use Generator;
+use ipl\Sql\Expression;
+use ipl\Sql\ExpressionInterface;
+use RuntimeException;
+
+class ResolvedExpression extends Expression
+{
+    /** @var Generator */
+    protected $resolvedColumns;
+
+    /**
+     * Create a resolved database expression
+     *
+     * @param ExpressionInterface $expr The original expression
+     * @param Generator $resolvedColumns The generator as returned by {@see Resolver::requireAndResolveColumns()}
+     */
+    public function __construct(ExpressionInterface $expr, Generator $resolvedColumns)
+    {
+        parent::__construct($expr->getStatement(), $expr->getColumns(), ...$expr->getValues());
+
+        $this->resolvedColumns = $resolvedColumns;
+    }
+
+    /**
+     * @throws RuntimeException In case the columns are not qualified yet
+     */
+    public function getColumns()
+    {
+        if ($this->resolvedColumns->valid()) {
+            throw new RuntimeException('Columns are not yet qualified');
+        }
+
+        return parent::getColumns();
+    }
+
+    /**
+     * Get the resolved column generator
+     *
+     * @return Generator
+     */
+    public function getResolvedColumns()
+    {
+        return $this->resolvedColumns;
+    }
+}

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -11,6 +11,8 @@ use OutOfBoundsException;
 use RuntimeException;
 use SplObjectStorage;
 
+use function ipl\Stdlib\get_php_type;
+
 /**
  * Column and relation resolver. Acts as glue between queries and models
  */
@@ -263,27 +265,48 @@ class Resolver
     /**
      * Qualify the given columns by the specified model
      *
-     * @param array $columns
-     * @param Model $model
+     * @param iterable $columns
+     * @param Model $model Leave null in case $columns is {@see Resolver::requireAndResolveColumns()}
      *
      * @return array
+     *
+     * @throws InvalidArgumentException If $columns is not iterable
+     * @throws InvalidArgumentException If $model is not passed and $columns is not a generator
      */
-    public function qualifyColumns(array $columns, Model $model)
+    public function qualifyColumns($columns, Model $model = null)
     {
-        $modelAlias = $this->getAlias($model);
+        $target = $model ?: $this->query->getModel();
+        $targetAlias = $this->getAlias($target);
+
+        if (! is_iterable($columns)) {
+            throw new InvalidArgumentException(
+                sprintf('$columns is not iterable, got %s instead', get_php_type($columns))
+            );
+        }
 
         $qualified = [];
         foreach ($columns as $alias => $column) {
-            if ($column instanceof ExpressionInterface) {
-                $column = clone $column; // The expression may be part of a model and those shouldn't change implicitly
-                $column->setColumns($this->qualifyColumns($column->getColumns(), $model));
-            } elseif (($dot = strrpos($column, '.')) !== false) {
-                $modelAlias = $this->getAlias(
-                    $this->resolveRelation(substr($column, 0, $dot), $model)->getTarget()
+            if (is_int($alias) && is_array($column)) {
+                // $columns is $this->requireAndResolveColumns()
+                list($target, $alias, $columnName) = $column;
+                $targetAlias = $this->getAlias($target);
+
+                // Thanks to PHP 5.6 where `list` is evaluated from right to left. It will extract
+                // the values for `$target` and `$alias` then from the third argument (`$column`).
+                $column = $columnName;
+            } elseif ($target === null) {
+                throw new InvalidArgumentException(
+                    'Passing no model is only possible if $columns is a generator'
                 );
-                $column = $this->qualifyColumn(substr($column, $dot + 1), $modelAlias);
+            }
+
+            if ($column instanceof ResolvedExpression) {
+                $column->setColumns($this->qualifyColumns($column->getResolvedColumns()));
+            } elseif ($column instanceof ExpressionInterface) {
+                $column = clone $column; // The expression may be part of a model and those shouldn't change implicitly
+                $column->setColumns($this->qualifyColumns($column->getResolvedColumns(), $target));
             } else {
-                $column = $this->qualifyColumn($column, $modelAlias);
+                $column = $this->qualifyColumn($column, $targetAlias);
             }
 
             $qualified[$alias] = $column;
@@ -295,42 +318,58 @@ class Resolver
     /**
      * Qualify the given columns and aliases by the specified model
      *
-     * @param array $columns
-     * @param Model $model
+     * @param iterable $columns
+     * @param Model $model Leave null in case $columns is {@see Resolver::requireAndResolveColumns()}
      * @param bool $autoAlias Set an alias for columns which have none
      *
      * @return array
+     *
+     * @throws InvalidArgumentException If $columns is not iterable
+     * @throws InvalidArgumentException If $model is not passed and $columns is not a generator
      */
-    public function qualifyColumnsAndAliases(array $columns, Model $model, $autoAlias = true)
+    public function qualifyColumnsAndAliases($columns, Model $model = null, $autoAlias = true)
     {
-        $modelAlias = $this->getAlias($model);
+        $target = $model ?: $this->query->getModel();
+        $targetAlias = $this->getAlias($target);
+
+        if (! is_iterable($columns)) {
+            throw new InvalidArgumentException(
+                sprintf('$columns is not iterable, got %s instead', get_php_type($columns))
+            );
+        }
 
         $qualified = [];
         foreach ($columns as $alias => $column) {
+            if (is_int($alias) && is_array($column)) {
+                // $columns is $this->requireAndResolveColumns()
+                list($target, $alias, $columnName) = $column;
+                $targetAlias = $this->getAlias($target);
+
+                // Thanks to PHP 5.6 where `list` is evaluated from right to left. It will extract
+                // the values for `$target` and `$alias` then from the third argument (`$column`).
+                $column = $columnName;
+            } elseif ($target === null) {
+                throw new InvalidArgumentException(
+                    'Passing no model is only possible if $columns is a generator'
+                );
+            }
+
             if (is_int($alias)) {
                 // TODO: Provide an alias for expressions nonetheless? (One without won't be hydrated)
                 if ($autoAlias && ! $column instanceof ExpressionInterface) {
-                    $alias = $this->qualifyColumnAlias($column, $modelAlias);
+                    $alias = $this->qualifyColumnAlias($column, $targetAlias);
                 }
-            } elseif (($dot = strrpos($alias, '.')) !== false) {
-                $modelAlias = $this->getAlias(
-                    $this->resolveRelation(substr($alias, 0, $dot), $model)->getTarget()
-                );
-                $alias = $this->qualifyColumnAlias(substr($alias, $dot + 1), $modelAlias);
-            } elseif ($model !== $this->query->getModel()) {
-                $alias = $this->qualifyColumnAlias($alias, $modelAlias);
+            } elseif ($target !== $this->query->getModel()) {
+                $alias = $this->qualifyColumnAlias($alias, $targetAlias);
             }
 
-            if ($column instanceof ExpressionInterface) {
+            if ($column instanceof ResolvedExpression) {
+                $column->setColumns($this->qualifyColumns($column->getResolvedColumns()));
+            } elseif ($column instanceof ExpressionInterface) {
                 $column = clone $column; // The expression may be part of a model and those shouldn't change implicitly
-                $column->setColumns($this->qualifyColumns($column->getColumns(), $model));
-            } elseif (($dot = strrpos($column, '.')) !== false) {
-                $modelAlias = $this->getAlias(
-                    $this->resolveRelation(substr($column, 0, $dot), $model)->getTarget()
-                );
-                $column = $this->qualifyColumn(substr($column, $dot + 1), $modelAlias);
+                $column->setColumns($this->qualifyColumns($column->getColumns(), $target));
             } else {
-                $column = $this->qualifyColumn($column, $modelAlias);
+                $column = $this->qualifyColumn($column, $targetAlias);
             }
 
             $qualified[$alias] = $column;
@@ -476,36 +515,46 @@ class Resolver
      * Related models will be automatically added for eager-loading.
      *
      * @param array $columns
+     * @param Model $model
      *
      * @return Generator
      *
      * @throws RuntimeException If a column does not exist
      */
-    public function requireAndResolveColumns(array $columns)
+    public function requireAndResolveColumns(array $columns, Model $model = null)
     {
-        $model = $this->query->getModel();
+        $model = $model ?: $this->query->getModel();
         $tableName = $model->getTableName();
 
         foreach ($columns as $alias => $column) {
+            $columnPath = &$column;
             if ($column instanceof ExpressionInterface) {
-                foreach ($this->requireAndResolveColumns($column->getColumns()) as $_) {
-                    // Only the expression itself is part of the select
-                }
-            }
+                $column = new ResolvedExpression(
+                    $column,
+                    $this->requireAndResolveColumns($column->getColumns(), $model)
+                );
 
-            if ($column === '*' || $column instanceof ExpressionInterface) {
+                if (is_int($alias)) {
+                    // Scalar queries and such
+                    yield [$model, $alias, $column];
+
+                    continue;
+                }
+
+                $columnPath = &$alias;
+            } elseif ($column === '*') {
                 yield [$model, $alias, $column];
 
                 continue;
             }
 
-            $dot = strrpos($column, '.');
+            $dot = strrpos($columnPath, '.');
 
             switch (true) {
                 /** @noinspection PhpMissingBreakStatementInspection */
                 case $dot !== false:
-                    $relation = substr($column, 0, $dot);
-                    $column = substr($column, $dot + 1);
+                    $relation = substr($columnPath, 0, $dot);
+                    $columnPath = substr($columnPath, $dot + 1); // Updates also $column or $alias
 
                     if ($relation !== $tableName) {
                         $relation = $this->qualifyPath($relation, $tableName);
@@ -521,10 +570,10 @@ class Resolver
                     $target = $model;
             }
 
-            if (! $this->hasSelectableColumn($target, $column)) {
+            if (! $column instanceof ExpressionInterface && ! $this->hasSelectableColumn($target, $columnPath)) {
                 throw new RuntimeException(sprintf(
                     "Can't require column '%s' in model '%s'. Column not found.",
-                    $column,
+                    $columnPath,
                     get_class($target)
                 ));
             }

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -322,7 +322,8 @@ class Resolver
             }
 
             if ($column instanceof ExpressionInterface) {
-                $column->setColumns($this->qualifyColumnsAndAliases($column->getColumns(), $model, $autoAlias));
+                $column = clone $column; // The expression may be part of a model and those shouldn't change implicitly
+                $column->setColumns($this->qualifyColumns($column->getColumns(), $model));
             } elseif (($dot = strrpos($column, '.')) !== false) {
                 $modelAlias = $this->getAlias(
                     $this->resolveRelation(substr($column, 0, $dot), $model)->getTarget()

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -285,6 +285,8 @@ class Resolver
                     $this->resolveRelation(substr($alias, 0, $dot), $model)->getTarget()
                 );
                 $alias = $this->qualifyColumnAlias(substr($alias, $dot + 1), $modelAlias);
+            } elseif ($model !== $this->query->getModel()) {
+                $alias = $this->qualifyColumnAlias($alias, $modelAlias);
             }
 
             if ($column instanceof ExpressionInterface) {

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -570,7 +570,11 @@ class Resolver
                     $target = $model;
             }
 
-            if (! $column instanceof ExpressionInterface && ! $this->hasSelectableColumn($target, $columnPath)) {
+            if (
+                ! $column instanceof ExpressionInterface
+                && ! $this->hasSelectableColumn($target, $columnPath)
+                && ! $this->hasSelectableColumn($target, $alias)
+            ) {
                 throw new RuntimeException(sprintf(
                     "Can't require column '%s' in model '%s'. Column not found.",
                     $columnPath,

--- a/tests/Car.php
+++ b/tests/Car.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\Model;
+use ipl\Orm\Relations;
+
+class Car extends Model
+{
+    public function getTableName()
+    {
+        return 'car';
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function getColumns()
+    {
+        return [
+            'model_name',
+            'manufacturer',
+            'model_name_lowered' => 'lower(model_name)'
+        ];
+    }
+
+    public function createRelations(Relations $relations)
+    {
+        $relations->hasMany('passenger', Passenger::class);
+    }
+}

--- a/tests/Passenger.php
+++ b/tests/Passenger.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\Model;
+use ipl\Orm\Relations;
+
+class Passenger extends Model
+{
+    public function getTableName()
+    {
+        return 'passenger';
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function getColumns()
+    {
+        return [
+            'car_id',
+            'name',
+            'gender' => 'sex'
+        ];
+    }
+
+    public function createRelations(Relations $relations)
+    {
+        $relations->belongsTo('car', Car::class);
+    }
+}

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -139,4 +139,30 @@ class QueryTest extends \PHPUnit\Framework\TestCase
             ->setModel(new User())
             ->with('invalid');
     }
+
+    public function testModelAliasesAreQualifiedButCustomAliasesAreNot()
+    {
+        $query = (new Query())
+            ->setModel(new Car())
+            ->with('passenger')
+            ->columns([
+                'gender' => 'manufacturer', // Collided previously with car_passenger_gender
+                'model_name_lowered' => 'model_name', // Only persists if custom aliases have preference
+                '*'
+            ]);
+
+        $this->assertSame(
+            [
+                'gender' => 'car.manufacturer',
+                'model_name_lowered' => 'car.model_name',
+                'car.id',
+                'car.model_name',
+                'car_passenger_id' => 'car_passenger.id',
+                'car_passenger_car_id' => 'car_passenger.car_id',
+                'car_passenger_name' => 'car_passenger.name',
+                'car_passenger_gender' => 'car_passenger.sex'
+            ],
+            $query->assembleSelect()->getColumns()
+        );
+    }
 }

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -99,6 +99,7 @@ class ResolverTest extends TestCase
             ->setModel($model)
             ->with('user');
 
+        $this->assertSame($qualified, $query->getResolver()->qualifyColumns($columns, $model));
         $this->assertSame($qualified, $query->getResolver()->qualifyColumnsAndAliases($columns, $model, false));
 
         $model = $query->getWith()['profile.user']->getTarget();


### PR DESCRIPTION
Notable changes:

* `Resolver::requireAndResolveColumns()` now transforms instances of `ipl\Sql\Expression` to `ipl\Orm\ResolvedExpression` which can't be used further without being qualified
* Removed `array` type declaration for param `$columns` in `Resolver::qualifyColumnsAndAliases()` to allow passing the result of `Resolver::requireAndResolveColumns()`
* Re-introduced `Resolver::qualifyColumns()`