### PR TITLE
Fix candidate key usage in `Query::createSubQuery()`

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -568,11 +568,12 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
         $subQueryConditions = [];
         foreach ((array) $this->getModel()->getKeyName() as $column) {
             $fk = $subQueryResolver->qualifyColumn($column, $sourceAlias);
+            $ck = $from !== null ? $from->getKeyName() : $column;
 
-            if (isset($from->$column)) {
-                $subQueryConditions["$fk = ?"] = $from->$column;
+            if (isset($from->$ck)) {
+                $subQueryConditions["$fk = ?"] = $from->$ck;
             } else {
-                $subQueryConditions[] = "$fk = " . $resolver->qualifyColumn($column, $baseAlias);
+                $subQueryConditions[] = "$fk = " . $resolver->qualifyColumn($ck, $baseAlias);
             }
         }
 


### PR DESCRIPTION
This is an attempt to fix an issue where accessing `$host->last_comment->author` will throw if `host.last_comment` has not been joined already.