### PR TITLE
Properly respect custom keys in through models

### DIFF
--- a/src/Relation/BelongsToMany.php
+++ b/src/Relation/BelongsToMany.php
@@ -162,8 +162,8 @@ class BelongsToMany extends Relation
             if ($relations->has($target->getTableName())) {
                 $targetRelation = $relations->get($target->getTableName());
 
-                $possibleTargetCandidateKey[] = $targetRelation->getForeignKey();
-                $possibleTargetForeignKey[] = $targetRelation->getCandidateKey();
+                $possibleTargetCandidateKey[] = $targetRelation->getCandidateKey();
+                $possibleTargetForeignKey[] = $targetRelation->getForeignKey();
             }
         }
 

--- a/tests/BelongsToManyTest.php
+++ b/tests/BelongsToManyTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\Relations;
+
+class BelongsToManyTest extends \PHPUnit\Framework\TestCase
+{
+    public function testResolveDefaultKeys()
+    {
+        $model = new Car();
+        $relations = new Relations();
+        $model->createRelations($relations);
+        $expected = [
+            [
+                'from'          => 'car',
+                'to'            => 'car_user',
+                'candidate_key' => 'id',
+                'foreign_key'   => 'car_id'
+            ],
+            [
+                'from'          => 'car_user',
+                'to'            => 'user',
+                'candidate_key' => 'user_id',
+                'foreign_key'   => 'id'
+            ]
+        ];
+        $actual = [];
+        foreach (
+            $relations
+                ->get('user')
+                ->setSource($model)
+                ->resolve() as list($from, $to, $keys)
+        ) {
+            reset($keys);
+            $actual[] = [
+                'from'          => $from->getTableName(),
+                'to'            => $to->getTableName(),
+                'candidate_key' => current($keys),
+                'foreign_key'   => key($keys)
+            ];
+        }
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testResolveRespectsCustomKeysInTroughModels()
+    {
+        $model = new Car();
+        $relations = new Relations();
+        $model->createRelations($relations);
+        $expected = [
+            [
+                'from'          => 'car',
+                'to'            => 'car_user',
+                'candidate_key' => 'car_custom_foreign_key',
+                'foreign_key'   => 'car_user_car_candidate_key'
+            ],
+            [
+                'from'          => 'car_user',
+                'to'            => 'user',
+                'candidate_key' => 'car_user_user_candidate_key',
+                'foreign_key'   => 'user_custom_foreign_key'
+            ]
+        ];
+        $actual = [];
+        foreach (
+            $relations
+                ->get('user_custom_keys')
+                ->setSource($model)
+                ->resolve() as list($from, $to, $keys)
+        ) {
+            reset($keys);
+            $actual[] = [
+                'from'          => $from->getTableName(),
+                'to'            => $to->getTableName(),
+                'candidate_key' => current($keys),
+                'foreign_key'   => key($keys)
+            ];
+        }
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Car.php
+++ b/tests/Car.php
@@ -29,5 +29,11 @@ class Car extends Model
     public function createRelations(Relations $relations)
     {
         $relations->hasMany('passenger', Passenger::class);
+
+        $relations->belongsToMany('user', User::class)
+            ->through(CarUser::class);
+
+        $relations->belongsToMany('user_custom_keys', User::class)
+            ->through(CarUserWithCustomKeys::class);
     }
 }

--- a/tests/CarUser.php
+++ b/tests/CarUser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\Model;
+use ipl\Orm\Relations;
+
+class CarUser extends Model
+{
+    public function getTableName()
+    {
+        return 'car_user';
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function getColumns()
+    {
+        return [
+            'car_id',
+            'user_id'
+        ];
+    }
+
+    public function createRelations(Relations $relations)
+    {
+        $relations->hasMany('car', Car::class);
+
+        $relations->hasMany('user', User::class);
+    }
+}

--- a/tests/CarUserWithCustomKeys.php
+++ b/tests/CarUserWithCustomKeys.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\Model;
+use ipl\Orm\Relations;
+
+class CarUserWithCustomKeys extends Model
+{
+    public function getTableName()
+    {
+        return 'car_user';
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function getColumns()
+    {
+        return [
+            'car_id',
+            'user_id'
+        ];
+    }
+
+    public function createRelations(Relations $relations)
+    {
+        $relations->hasMany('car', Car::class)
+            ->setCandidateKey('car_user_car_candidate_key')
+            ->setForeignKey('car_custom_foreign_key');
+
+        $relations->hasMany('user', User::class)
+            ->setCandidateKey('car_user_user_candidate_key')
+            ->setForeignKey('user_custom_foreign_key');
+    }
+}

--- a/tests/User.php
+++ b/tests/User.php
@@ -34,5 +34,8 @@ class User extends Model
             ->through('user_group');
 
         $relations->hasMany('audit', Audit::class);
+
+        $relations->belongsToMany('car', Car::class)
+            ->through(CarUser::class);
     }
 }


### PR DESCRIPTION
Previously, when using a through model that sets custom keys,
the keys from the through model to the target model were the wrong
way round. This PR doesn't fix that it might make sense to let the
first custom key defined win instead of the last.