### PR TITLE
Require Query in Resolver::__construct()

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -229,8 +229,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     public function getResolver()
     {
         if ($this->resolver === null) {
-            $this->resolver = (new Resolver())
-                ->setQuery($this);
+            $this->resolver = new Resolver($this);
         }
 
         return $this->resolver;
@@ -828,7 +827,6 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     public function __clone()
     {
         $this->resolver = clone $this->resolver;
-        $this->resolver->setQuery($this);
 
         if ($this->filter !== null) {
             $this->filter = clone $this->filter;

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -48,9 +48,13 @@ class Resolver
 
     /**
      * Create a new resolver
+     *
+     * @param Query $query The query to resolve
      */
-    public function __construct()
+    public function __construct(Query $query)
     {
+        $this->query = $query;
+
         $this->relations = new SplObjectStorage();
         $this->behaviors = new SplObjectStorage();
         $this->aliases = new SplObjectStorage();
@@ -58,20 +62,6 @@ class Resolver
         $this->selectColumns = new SplObjectStorage();
         $this->metaData = new SplObjectStorage();
         $this->resolvedRelations = new SplObjectStorage();
-    }
-
-    /**
-     * Set the query this resolver belongs to
-     *
-     * @param Query $query
-     *
-     * @return $this
-     */
-    public function setQuery(Query $query)
-    {
-        $this->query = $query;
-
-        return $this;
     }
 
     /**

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -34,7 +34,7 @@ class ResolverTest extends TestCase
     public function testGetSelectColumnsReturnsEmptyArrayIfPrimaryKeyAndColumnsAreEmpty()
     {
         $model = new TestModel();
-        $resolver = new Resolver();
+        $resolver = (new Query())->getResolver();
         $columns = $resolver->getSelectColumns($model);
 
         $this->assertTrue(is_array($columns));
@@ -44,7 +44,7 @@ class ResolverTest extends TestCase
     public function testGetSelectColumnsOnlyReturnsThePrimaryKeyAsArrayIfThereIsOnlyThePrimaryKeyAndItIsAString()
     {
         $model = new TestModelWithPrimaryKey();
-        $resolver = new Resolver();
+        $resolver = (new Query())->getResolver();
 
         $this->assertSame((array) $model->getKeyName(), $resolver->getSelectColumns($model));
     }
@@ -52,7 +52,7 @@ class ResolverTest extends TestCase
     public function testGetSelectColumnsOnlyReturnsTheCompoundPrimaryKeyAsArrayIfTheresOnlyThePrimaryKeyAndItsCompound()
     {
         $model = new TestModelWithCompoundPrimaryKey();
-        $resolver = new Resolver();
+        $resolver = (new Query())->getResolver();
 
         $this->assertSame($model->getKeyName(), $resolver->getSelectColumns($model));
     }
@@ -60,7 +60,7 @@ class ResolverTest extends TestCase
     public function testGetSelectColumnsOnlyReturnsTheColumnsIfThereIsNoPrimaryKey()
     {
         $model = new TestModelWithColumns();
-        $resolver = new Resolver();
+        $resolver = (new Query())->getResolver();
 
         $this->assertSame($model->getColumns(), $resolver->getSelectColumns($model));
     }
@@ -68,7 +68,7 @@ class ResolverTest extends TestCase
     public function testGetSelectColumnsReturnsPrimaryKeyPlusColumnsInThatOrder()
     {
         $model = new TestModelWithPrimaryKeyAndColumns();
-        $resolver = new Resolver();
+        $resolver = (new Query())->getResolver();
 
         $this->assertSame(
             array_merge((array) $model->getKeyName(), $model->getColumns()),
@@ -79,7 +79,7 @@ class ResolverTest extends TestCase
     public function testGetSelectColumnsReturnsCompoundPrimaryKeyPlusColumnsInThatOrder()
     {
         $model = new TestModelWithCompoundPrimaryKeyAndColumns();
-        $resolver = new Resolver();
+        $resolver = (new Query())->getResolver();
 
         $this->assertSame(array_merge($model->getKeyName(), $model->getColumns()), $resolver->getSelectColumns($model));
     }


### PR DESCRIPTION
This is an unimplemented feature yet, but behaviors may be query dependent and the resolver allows for lazy initialization of the query, which makes things unnecessarily complicated when implementing this feature.
The resolver is dependent on the query anyway, so it's easier if the query is already required to build the resolver.