### PR TITLE
Allow to select aliased model columns explicitly

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -807,15 +807,19 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
             $selectColumns = $resolver->getSelectColumns($model);
             $tableName = $resolver->getAlias($model);
 
-            if (isset($selectColumns[$column])) {
-                $column = $selectColumns[$column];
-            }
+            if (! is_int($alias)) {
+                $orderByResolved[] = [$alias, $direction];
+            } else {
+                if (isset($selectColumns[$column])) {
+                    $column = $selectColumns[$column];
+                }
 
-            if (is_string($column)) {
-                $column = $resolver->qualifyColumn($column, $tableName);
-            }
+                if (is_string($column)) {
+                    $column = $resolver->qualifyColumn($column, $tableName);
+                }
 
-            $orderByResolved[] = [$column, $direction];
+                $orderByResolved[] = [$column, $direction];
+            }
 
             array_shift($columnsAndDirections);
         }

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -541,6 +541,7 @@ class Resolver
     {
         $model = $model ?: $this->query->getModel();
         $tableName = $model->getTableName();
+        $targetColumns = $model->getColumns();
 
         foreach ($columns as $alias => $column) {
             $columnPath = &$column;
@@ -598,14 +599,18 @@ class Resolver
 
             if (! $column instanceof ExpressionInterface) {
                 $column = $this->getBehaviors($target)->rewriteColumn($column, $relationPath) ?: $column;
-            }
 
-            if (
-                ! $column instanceof ExpressionInterface
-                && ! $this->hasSelectableColumn($target, $columnPath)
-                && ! $this->hasSelectableColumn($target, $alias)
-            ) {
-                throw new InvalidColumnException($columnPath, $target);
+                if (
+                    ! $this->hasSelectableColumn($target, $columnPath)
+                    && ! $this->hasSelectableColumn($target, $alias)
+                ) {
+                    throw new InvalidColumnException($columnPath, $target);
+                }
+
+                if (isset($targetColumns[$column])) {
+                    $alias = is_int($alias) ? $column : $alias;
+                    $column = $targetColumns[$column];
+                }
             }
 
             yield [$target, $alias, $column];

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -135,6 +135,54 @@ class SqlTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSelectFromModelWithAliasedOrderByColumnBeingSelected()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns('lorem')
+            ->orderBy('lorem');
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS lorem FROM test ORDER BY lorem',
+            $query->assembleSelect()
+        );
+    }
+
+    public function testSelectFromModelWithAliasedOrderByColumnBeingSelectedWithAlias()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns(['alias' => 'lorem'])
+            ->orderBy('lorem');
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS alias FROM test ORDER BY alias',
+            $query->assembleSelect()
+        );
+    }
+
+    public function testSelectFromModelWithAliasedOrderByColumnNotBeingSelected()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns('lorem')
+            ->orderBy('ipsum');
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS lorem FROM test ORDER BY (MIN(test.ipsum))',
+            $query->assembleSelect()
+        );
+    }
+
     public function testSelectFromModelWithLimit()
     {
         $this->setupTest();

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -105,6 +105,36 @@ class SqlTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSelectFromModelWithExplicitAliasedModelColumns()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns(['lorem']);
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS lorem FROM test',
+            $query->assembleSelect()
+        );
+    }
+
+    public function testSelectFromModelWithExplicitAliasedAliasedModelColumns()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns(['alias' => 'ipsum']);
+
+        $this->assertSql(
+            'SELECT (MIN(test.ipsum)) AS alias FROM test',
+            $query->assembleSelect()
+        );
+    }
+
     public function testSelectFromModelWithLimit()
     {
         $this->setupTest();

--- a/tests/TestModelWithAliasedColumns.php
+++ b/tests/TestModelWithAliasedColumns.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Sql\Expression;
+
+class TestModelWithAliasedColumns extends TestModel
+{
+    public function getColumns()
+    {
+        return [
+            'lorem' => new Expression('MAX(test.lorem)'),
+            'ipsum' => new Expression('MIN(test.ipsum)')
+        ];
+    }
+}


### PR DESCRIPTION
With this PR it is no longer possible to order by aliased columns, e.g. severity in the host group overview. So I created #41. Please see both PRs as draft.