### PR TITLE
Don't perform subquery filter on utilized()d relations

### DIFF
--- a/src/Compat/FilterProcessor.php
+++ b/src/Compat/FilterProcessor.php
@@ -165,7 +165,11 @@ class FilterProcessor extends \ipl\Sql\Compat\FilterProcessor
                             $optimizeChild !== null && $optimizeChild
                             || (
                                 $optimizeChild === null
-                                && ! isset($query->getWith()[$relationPath]) // Not a selected join
+                                && ! (
+                                    // Not a selected join
+                                    isset($this->baseJoins[$relationPath])
+                                    || isset($query->getWith()[$relationPath])
+                                )
                                 && ! $query->getResolver()->isDistinctRelation($relationPath) // Not a to-one relation
                             )
                         )


### PR DESCRIPTION
Previously, the filter processor considered only with()ed relations when
deciding whether to perform a subquery filter. utilize()d relations are
now also taken into account.