### PR TITLE
Introduce class `ipl\Orm\AliasedExpression`

### DIFF
--- a/src/AliasedExpression.php
+++ b/src/AliasedExpression.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ipl\Orm;
+
+use ipl\Sql\Expression;
+
+class AliasedExpression extends Expression
+{
+    /** @var string */
+    protected $alias;
+
+    /**
+     * Create a new database expression
+     *
+     * @param string $alias     The alias to use for the expression, this is expected to be quoted and qualified
+     * @param string $statement The statement of the expression
+     * @param ?array $columns   The columns used by the expression
+     * @param mixed ...$values  The values for the expression
+     */
+    public function __construct(string $alias, string $statement, array $columns = null, ...$values)
+    {
+        parent::__construct($statement, $columns, ...$values);
+
+        $this->alias = $alias;
+    }
+
+    /**
+     * Get this expression's alias
+     *
+     * @return string
+     */
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+}

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -353,8 +353,9 @@ class Resolver
             }
 
             if (is_int($alias)) {
-                // TODO: Provide an alias for expressions nonetheless? (One without won't be hydrated)
-                if ($autoAlias && ! $column instanceof ExpressionInterface) {
+                if ($column instanceof AliasedExpression) {
+                    $alias = $column->getAlias();
+                } elseif ($autoAlias && ! $column instanceof ExpressionInterface) {
                     $alias = $this->qualifyColumnAlias($column, $targetAlias);
                 }
             } elseif ($target !== $this->query->getModel()) {


### PR DESCRIPTION
Instances of other expression types are still not aliased automatically. It's just not possible otherwise, if random aliases are no option. (They're not)