### PR TITLE
Allow order by aliased expressions

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -743,11 +743,19 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
         $columnsAndDirections = [];
         $orderByResolved = [];
         $resolver = $this->getResolver();
+        $selectedColumns = $select->getColumns();
 
-        // Prepare flat ORDER BY column(s) and direction(s) for requireAndResolveColumns()
         foreach ($orderBy as $part) {
             list($column, $direction) = $part;
-            $columnsAndDirections[$column] = $direction;
+
+            if (isset($selectedColumns[$column])) {
+                // If it's a custom alias, we have no other way of knowing it,
+                // unless the caller explicitly uses it in the sort rule.
+                $orderByResolved[] = $part;
+            } else {
+                // Prepare flat ORDER BY column(s) and direction(s) for requireAndResolveColumns()
+                $columnsAndDirections[$column] = $direction;
+            }
         }
 
         foreach (

--- a/src/Query.php
+++ b/src/Query.php
@@ -757,12 +757,16 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
             $selectColumns = $resolver->getSelectColumns($model);
             $tableName = $resolver->getAlias($model);
 
-            if (isset($selectColumns[$column])) {
-                $column = $selectColumns[$column];
-            }
+            if ($column instanceof AliasedExpression) {
+                $column = is_string($alias) ? $alias : $column->getAlias();
+            } else {
+                if (isset($selectColumns[$column])) {
+                    $column = $selectColumns[$column];
+                }
 
-            if (is_string($column)) {
-                $column = $resolver->qualifyColumn($column, $tableName);
+                if (is_string($column)) {
+                    $column = $resolver->qualifyColumn($column, $tableName);
+                }
             }
 
             $orderByResolved[] = [$column, $direction];

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -652,6 +652,22 @@ class Resolver
                     }
             }
 
+            if (! $column instanceof ExpressionInterface) {
+                $targetColumns = $target->getColumns();
+                if (isset($targetColumns[$column])) {
+                    // $column is actually an alias
+                    $alias = is_int($alias) ? $column : $alias;
+                    $column = $targetColumns[$column];
+
+                    if ($column instanceof ExpressionInterface) {
+                        $column = new ResolvedExpression(
+                            $column,
+                            $this->requireAndResolveColumns($column->getColumns(), $target)
+                        );
+                    }
+                }
+            }
+
             if (
                 ! $column instanceof ExpressionInterface
                 && ! $this->hasSelectableColumn($target, $columnPath)

--- a/tests/ApiIdentity.php
+++ b/tests/ApiIdentity.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\AliasedExpression;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Contract\RewriteBehavior;
+use ipl\Orm\Model;
+use ipl\Orm\Relations;
+use ipl\Stdlib\Filter\Condition;
+
+class ApiIdentity extends Model
+{
+    public function getTableName()
+    {
+        return 'api_identity';
+    }
+
+    public function getKeyName()
+    {
+        return 'id';
+    }
+
+    public function getColumns()
+    {
+        return [
+            'user_id',
+            'api_token'
+        ];
+    }
+
+    public function createBehaviors(Behaviors $behaviors)
+    {
+        $rewriteBehavior = new class () implements RewriteBehavior {
+            public function rewritePath($path, $relation = null)
+            {
+            }
+
+            public function rewriteColumn($column, $relation = null)
+            {
+                if ($column === 'api_token') {
+                    $relation = str_replace('.', '_', $relation);
+                    return new AliasedExpression("{$relation}_api_token", '"api_token retrieval not permitted"');
+                }
+            }
+
+            public function rewriteCondition(Condition $condition, $relation = null)
+            {
+            }
+        };
+
+        $behaviors->add($rewriteBehavior);
+    }
+
+    public function createRelations(Relations $relations)
+    {
+        $relations->belongsTo('user', User::class);
+    }
+}

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -173,4 +173,19 @@ class QueryTest extends \PHPUnit\Framework\TestCase
             $query->assembleSelect()->getColumns()
         );
     }
+
+    public function testAliasIsUsedForAliasedExpressionsInOrderBy()
+    {
+        $query = (new Query())
+            ->setModel(new User())
+            ->columns('api_identity.api_token')
+            ->orderBy('api_identity.api_token', 'desc');
+
+        $orderBy = $query->assembleSelect()->getOrderBy();
+
+        $this->assertSame(
+            [['user_api_identity_api_token', 'desc']],
+            $orderBy
+        );
+    }
 }

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -135,6 +135,54 @@ class SqlTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSelectFromModelWithAliasedOrderByColumnBeingSelected()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns('lorem')
+            ->orderBy('lorem');
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS lorem FROM test ORDER BY lorem',
+            $query->assembleSelect()
+        );
+    }
+
+    public function testSelectFromModelWithAliasedOrderByColumnBeingSelectedWithAlias()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns(['alias' => 'lorem'])
+            ->orderBy('lorem');
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS alias FROM test ORDER BY alias',
+            $query->assembleSelect()
+        );
+    }
+
+    public function testSelectFromModelWithAliasedOrderByColumnNotBeingSelected()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns('lorem')
+            ->orderBy('ipsum');
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS lorem FROM test ORDER BY (MIN(test.ipsum))',
+            $query->assembleSelect()
+        );
+    }
+
     public function testSelectFromModelWithLimit()
     {
         $this->setupTest();

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -178,7 +178,7 @@ class SqlTest extends \PHPUnit\Framework\TestCase
             ->orderBy('ipsum');
 
         $this->assertSql(
-            'SELECT (MAX(test.lorem)) AS lorem FROM test ORDER BY (MIN(test.ipsum))',
+            'SELECT (MAX(test.lorem)) AS lorem FROM test ORDER BY MIN(test.ipsum)',
             $query->assembleSelect()
         );
     }

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -105,6 +105,36 @@ class SqlTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSelectFromModelWithExplicitAliasedModelColumns()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns(['lorem']);
+
+        $this->assertSql(
+            'SELECT (MAX(test.lorem)) AS lorem FROM test',
+            $query->assembleSelect()
+        );
+    }
+
+    public function testSelectFromModelWithExplicitAliasedAliasedModelColumns()
+    {
+        $this->setupTest();
+
+        $model = new TestModelWithAliasedColumns();
+        $query = (new Query())
+            ->setModel($model)
+            ->columns(['alias' => 'ipsum']);
+
+        $this->assertSql(
+            'SELECT (MIN(test.ipsum)) AS alias FROM test',
+            $query->assembleSelect()
+        );
+    }
+
     public function testSelectFromModelWithLimit()
     {
         $this->setupTest();

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -159,7 +159,7 @@ class SqlTest extends \PHPUnit\Framework\TestCase
         $query = (new Query())
             ->setModel($model)
             ->columns(['alias' => 'lorem'])
-            ->orderBy('lorem');
+            ->orderBy('alias');
 
         $this->assertSql(
             'SELECT (MAX(test.lorem)) AS alias FROM test ORDER BY alias',

--- a/tests/TestModelWithAliasedColumns.php
+++ b/tests/TestModelWithAliasedColumns.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Sql\Expression;
+
+class TestModelWithAliasedColumns extends TestModel
+{
+    public function getColumns()
+    {
+        return [
+            'lorem' => new Expression('MAX(test.lorem)'),
+            'ipsum' => new Expression('MIN(test.ipsum)')
+        ];
+    }
+}

--- a/tests/User.php
+++ b/tests/User.php
@@ -28,6 +28,7 @@ class User extends Model
     public function createRelations(Relations $relations)
     {
         $relations->hasOne('profile', Profile::class);
+        $relations->hasOne('api_identity', ApiIdentity::class);
 
         $relations
             ->belongsToMany('group', Group::class)


### PR DESCRIPTION
Tested with MySQL and PostgreSQL using custom variables and other relations. (e.g. `hostgroup.name` and `user.name`)