### PR TITLE
Resolver: Don't *with* relations that are required by expressions

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -530,12 +530,13 @@ class Resolver
      *
      * @param array $columns
      * @param Model $model
+     * @param bool $utilize Pass true in order to just utilize referenced relations
      *
      * @return Generator
      *
      * @throws InvalidColumnException If a column does not exist
      */
-    public function requireAndResolveColumns(array $columns, Model $model = null)
+    public function requireAndResolveColumns(array $columns, Model $model = null, $utilize = false)
     {
         $model = $model ?: $this->query->getModel();
         $tableName = $model->getTableName();
@@ -545,7 +546,7 @@ class Resolver
             if ($column instanceof ExpressionInterface) {
                 $column = new ResolvedExpression(
                     $column,
-                    $this->requireAndResolveColumns($column->getColumns(), $model)
+                    $this->requireAndResolveColumns($column->getColumns(), $model, true)
                 );
 
                 if (is_int($alias)) {
@@ -583,7 +584,12 @@ class Resolver
                             $alias = "$hydrationPath.$column";
                         }
 
-                        $this->query->with($hydrationPath);
+                        if ($utilize) {
+                            $this->query->utilize($hydrationPath);
+                        } else {
+                            $this->query->with($hydrationPath);
+                        }
+
                         $target = $relation->getTarget();
 
                         break;

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Orm;
 
 use ipl\Orm\Exception\InvalidRelationException;
 use ipl\Orm\Query;
+use ipl\Sql\Expression;
 
 class QueryTest extends \PHPUnit\Framework\TestCase
 {
@@ -136,6 +137,23 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             $query->getResolver()->getRelations($query->getModel())->get('group'),
             $query->getWith()['user.group']
+        );
+    }
+
+    public function testExpressionsDontCauseRelationsToBeEagerLoaded()
+    {
+        $query = (new Query())
+            ->setModel(new User())
+            ->columns([
+                'expr' => new Expression(
+                    'HEX(%s)',
+                    ['profile.id']
+                )
+            ]);
+
+        $this->assertSame(
+            ['expr'],
+            array_keys($query->assembleSelect()->getColumns())
         );
     }
 


### PR DESCRIPTION
Such are now utilized instead. My reasoning for this simple change (I had another one in mind, but that turned out to be overkill) is:

Relations that are utilized, are not part of the select list. An expression is part of the select list of course, but it's an advanced structure which represents the column's value. How the value is composed is not of interest, so the relations required by the expression are not strictly part of the select, but part of the expression. :sweat_smile: 

Only makes sense once #58 is merged.