### PR TITLE
Change column methods

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -59,7 +59,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /** @var Model Model to query */
     protected $model;
 
-    /** @var array Columns to select from the model */
+    /** @var array Columns to select from the model (or its relations). If empty, all columns are selected */
     protected $columns = [];
 
     /** @var array Additional columns to select from the model (or its relations) */
@@ -232,10 +232,15 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
         return $this->disableDefaultSort;
     }
 
+
     /**
-     * Set columns to select from the model
+     * Set columns to select from the model (or its relations)
      *
-     * Multiple calls to this method will not overwrite the previous set columns but append the columns to the query.
+     * By default, i.e. if you do not specify any columns, all columns of the model and
+     * any relation added via {@see with()} will be selected.
+     * Multiple calls to this method will overwrite the previously specified columns.
+     * If you specify columns from the model's relations, the relations are automatically joined upon querying.
+     * Note that a call to this method also overwrites any previously column specified via {@see withColumns()}.
      *
      * @param string|array $columns The column(s) to select
      *
@@ -243,7 +248,8 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
      */
     public function columns($columns)
     {
-        $this->columns = array_merge($this->columns, (array) $columns);
+        $this->columns = (array) $columns;
+        $this->withColumns = [];
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -21,7 +21,6 @@ use ipl\Stdlib\Filter;
 use ipl\Stdlib\Filters;
 use IteratorAggregate;
 use ReflectionClass;
-use RuntimeException;
 use SplObjectStorage;
 use Traversable;
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -62,6 +62,9 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /** @var array Columns to select from the model */
     protected $columns = [];
 
+    /** @var array Additional columns to select from the model (or its relations) */
+    protected $withColumns = [];
+
     /** @var bool Whether to peek ahead for more results */
     protected $peekAhead = false;
 
@@ -241,6 +244,22 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     public function columns($columns)
     {
         $this->columns = array_merge($this->columns, (array) $columns);
+
+        return $this;
+    }
+
+    /**
+     * Set additional columns to select from the model (or its relations)
+     *
+     * Multiple calls to this method will not overwrite the previous set columns but append the columns to the query.
+     *
+     * @param string|array $columns The column(s) to select
+     *
+     * @return $this
+     */
+    public function withColumns($columns)
+    {
+        $this->withColumns = array_merge($this->withColumns, (array) $columns);
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -179,20 +179,6 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     }
 
     /**
-     * Set the columns to select from the model
-     *
-     * @param array $columns
-     *
-     * @return $this
-     */
-    public function setColumns(array $columns)
-    {
-        $this->columns = $columns;
-
-        return $this;
-    }
-
-    /**
      * Set the filter of the query
      *
      * @param Filter\Chain $filter

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -681,64 +681,6 @@ class Resolver
     }
 
     /**
-     * Require all remaining columns that are not already selected
-     *
-     * @param array $existingColumns The fully qualified columns that are already selected
-     * @param Model $model The model from which to fetch any remaining columns
-     *
-     * @return array
-     */
-    public function requireRemainingColumns(array $existingColumns, Model $model)
-    {
-        $modelColumns = $this->getSelectColumns($model);
-        if (empty($existingColumns)) {
-            return $modelColumns;
-        }
-
-        $modelAlias = $this->getAlias($model);
-        $isBaseModel = $model === $this->query->getModel();
-
-        foreach ($existingColumns as $alias => $columnPath) {
-            if (is_string($alias)) {
-                if ($isBaseModel || substr($alias, 0, strlen($modelAlias)) === $modelAlias) {
-                    if (! $isBaseModel) {
-                        $alias = substr($alias, strlen($modelAlias) + 1);
-                    }
-
-                    if (isset($modelColumns[$alias])) {
-                        unset($modelColumns[$alias]);
-                        continue;
-                    }
-                } else {
-                    continue;
-                }
-            }
-
-            if (is_string($columnPath) && substr($columnPath, 0, strlen($modelAlias)) === $modelAlias) {
-                $column = substr($columnPath, strlen($modelAlias) + 1);
-                if (($pos = array_search($column, $modelColumns, true)) !== false) {
-                    if (is_int($pos)) {
-                        // Explicit aliases can only be overridden with the same alias (see above)
-                        unset($modelColumns[$pos]);
-                        continue;
-                    }
-                }
-            }
-
-            // Not an alias match nor a column match. The only remaining match can be
-            // accomplished by checking whether a selected alias can be mapped to a
-            // column of the model.
-            if (is_string($alias) && ($pos = array_search($alias, $modelColumns, true)) !== false) {
-                if (is_int($pos)) {
-                    unset($modelColumns[$pos]);
-                }
-            }
-        }
-
-        return $modelColumns;
-    }
-
-    /**
      * Collect all selectable columns from the given model
      *
      * @param Model $subject

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -326,7 +326,7 @@ class Resolver
                 $column->setColumns($this->qualifyColumns($column->getResolvedColumns()));
             } elseif ($column instanceof ExpressionInterface) {
                 $column = clone $column; // The expression may be part of a model and those shouldn't change implicitly
-                $column->setColumns($this->qualifyColumns($column->getResolvedColumns(), $target));
+                $column->setColumns($this->qualifyColumns($column->getColumns(), $target));
             } else {
                 $column = $this->qualifyColumn($column, $targetAlias);
             }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -185,6 +185,22 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testExplicitColumnsDontCauseRelationsToBeImplicitlySelected()
+    {
+        $query = (new Query())
+            ->setModel(new User())
+            ->with('profile')
+            ->columns(['user.username', 'profile.surname']);
+
+        $this->assertSame(
+            [
+                'user.username',
+                'user_profile_surname' => 'user_profile.surname'
+            ],
+            $query->assembleSelect()->getColumns()
+        );
+    }
+
     public function testMultipleCallsToWithColumnsAreMerged()
     {
         $query = (new Query())

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -155,16 +155,13 @@ class QueryTest extends \PHPUnit\Framework\TestCase
             ->with('passenger')
             ->columns([
                 'gender' => 'manufacturer', // Collided previously with car_passenger_gender
-                'model_name_lowered' => 'model_name', // Only persists if custom aliases have preference
-                '*'
+                'model_name_lowered' => 'model_name' // Only persists if custom aliases have preference
             ]);
 
         $this->assertSame(
             [
                 'gender' => 'car.manufacturer',
                 'model_name_lowered' => 'car.model_name',
-                'car.id',
-                'car.model_name',
                 'car_passenger_id' => 'car_passenger.id',
                 'car_passenger_car_id' => 'car_passenger.car_id',
                 'car_passenger_name' => 'car_passenger.name',

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -63,7 +63,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($columns, $query->getColumns());
     }
 
-    public function testMultipleCallsToColumnsAreMerged()
+    public function testMultipleCallsToColumnsOverwriteEachOther()
     {
         $columns1 = ['lorem'];
         $columns2 = ['ipsum'];
@@ -71,7 +71,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase
             ->columns($columns1)
             ->columns($columns2);
 
-        $this->assertSame(array_merge($columns1, $columns2), $query->getColumns());
+        $this->assertSame($columns2, $query->getColumns());
     }
 
     public function testColumnsWithStringAsParameter()
@@ -152,19 +152,18 @@ class QueryTest extends \PHPUnit\Framework\TestCase
     {
         $query = (new Query())
             ->setModel(new Car())
-            ->with('passenger')
             ->columns([
-                'gender' => 'manufacturer', // Collided previously with car_passenger_gender
-                'model_name_lowered' => 'model_name' // Only persists if custom aliases have preference
+                'gender'             => 'manufacturer',
+                'model_name_lowered' => 'model_name',
+                'passenger.name',
+                'passenger.gender'
             ]);
 
         $this->assertSame(
             [
-                'gender' => 'car.manufacturer',
-                'model_name_lowered' => 'car.model_name',
-                'car_passenger_id' => 'car_passenger.id',
-                'car_passenger_car_id' => 'car_passenger.car_id',
-                'car_passenger_name' => 'car_passenger.name',
+                'gender'               => 'car.manufacturer',
+                'model_name_lowered'   => 'car.model_name',
+                'car_passenger_name'   => 'car_passenger.name',
                 'car_passenger_gender' => 'car_passenger.sex'
             ],
             $query->assembleSelect()->getColumns()

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -187,14 +187,14 @@ class SqlTest extends \PHPUnit\Framework\TestCase
     {
         $this->setupTest();
 
-        $model = new TestModelWithColumns();
+        $model = new TestModel();
         $query = (new Query())
             ->setModel($model)
-            ->columns('lorem')
+            ->columns('*')
             ->limit(25);
 
         $this->assertSql(
-            'SELECT test.lorem FROM test LIMIT 25',
+            'SELECT test.* FROM test LIMIT 25',
             $query->assembleSelect()
         );
     }
@@ -203,14 +203,14 @@ class SqlTest extends \PHPUnit\Framework\TestCase
     {
         $this->setupTest();
 
-        $model = new TestModelWithColumns();
+        $model = new TestModel();
         $query = (new Query())
             ->setModel($model)
-            ->columns('lorem')
+            ->columns('*')
             ->offset(25);
 
         $this->assertSql(
-            'SELECT test.lorem FROM test OFFSET 25',
+            'SELECT test.* FROM test OFFSET 25',
             $query->assembleSelect()
         );
     }
@@ -219,15 +219,15 @@ class SqlTest extends \PHPUnit\Framework\TestCase
     {
         $this->setupTest();
 
-        $model = new TestModelWithColumns();
+        $model = new TestModel();
         $query = (new Query())
             ->setModel($model)
-            ->columns('lorem')
+            ->columns('*')
             ->limit(25)
             ->offset(25);
 
         $this->assertSql(
-            'SELECT test.lorem FROM test LIMIT 25 OFFSET 25',
+            'SELECT test.* FROM test LIMIT 25 OFFSET 25',
             $query->assembleSelect()
         );
     }
@@ -265,11 +265,11 @@ SQL;
         $user = new User();
         $query = (new Query())
             ->setModel($user)
-            ->columns('username')
+            ->columns('*')
             ->with('profile');
 
         $this->assertSql(
-            'SELECT user.username FROM user INNER JOIN profile user_profile ON user_profile.user_id = user.id',
+            'SELECT user.* FROM user INNER JOIN profile user_profile ON user_profile.user_id = user.id',
             $query->assembleSelect()
         );
     }

--- a/tests/SqlTest.php
+++ b/tests/SqlTest.php
@@ -258,22 +258,6 @@ SQL;
         );
     }
 
-    public function testSelectFromModelWithEagerLoadingOfASingleOneToOneRelationAndExplicitColumnsToSelect()
-    {
-        $this->setupTest();
-
-        $user = new User();
-        $query = (new Query())
-            ->setModel($user)
-            ->columns('*')
-            ->with('profile');
-
-        $this->assertSql(
-            'SELECT user.* FROM user INNER JOIN profile user_profile ON user_profile.user_id = user.id',
-            $query->assembleSelect()
-        );
-    }
-
     public function testSelectFromModelWithEagerLoadingOfASingleOneToOneRelationInversed()
     {
         $this->setupTest();


### PR DESCRIPTION
This PR no longer makes `Query::columns()` additive and introduces `Query::withColumns()` to specify additional columns to select. This allows us to control at any point in time which columns should be selected exactly, but also specify additional columns if necessary.

closes #58 