### PR TITLE
Introduce column definitions

### DIFF
--- a/src/Behaviors.php
+++ b/src/Behaviors.php
@@ -217,4 +217,22 @@ class Behaviors implements IteratorAggregate
             $behavior->rewriteColumnDefinition($def, $relation);
         }
     }
+
+    /**
+     * Get whether the given column is selectable
+     *
+     * @param string $column
+     *
+     * @return bool
+     */
+    public function isSelectableColumn(string $column): bool
+    {
+        foreach ($this->rewriteColumnBehaviors as $behavior) {
+            if ($behavior->isSelectableColumn($column)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Behaviors.php
+++ b/src/Behaviors.php
@@ -202,4 +202,19 @@ class Behaviors implements IteratorAggregate
 
         return $newColumn;
     }
+
+    /**
+     * Rewrite the given column definition
+     *
+     * @param ColumnDefinition $def
+     * @param string $relation Absolute path of the model
+     *
+     * @return void
+     */
+    public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void
+    {
+        foreach ($this->rewriteColumnBehaviors as $behavior) {
+            $behavior->rewriteColumnDefinition($def, $relation);
+        }
+    }
 }

--- a/src/ColumnDefinition.php
+++ b/src/ColumnDefinition.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace ipl\Orm;
+
+use InvalidArgumentException;
+use LogicException;
+
+class ColumnDefinition
+{
+    /** @var string The name of the column */
+    protected $name;
+
+    /** @var ?string The label of the column */
+    protected $label;
+
+    /**
+     * Create a new column definition
+     *
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Get the column name
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the column label
+     *
+     * @return ?string
+     */
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    /**
+     * Set the column label
+     *
+     * @param ?string $label
+     *
+     * @return $this
+     */
+    public function setLabel(?string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Create a new column definition based on the given options
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public static function fromArray(array $options): self
+    {
+        if (! isset($options['name'])) {
+            throw new InvalidArgumentException('$options must provide a name');
+        }
+
+        $self = new static($options['name']);
+        if (isset($options['label'])) {
+            $self->setLabel($options['label']);
+        }
+
+        return $self;
+    }
+}

--- a/src/Contract/RewriteColumnBehavior.php
+++ b/src/Contract/RewriteColumnBehavior.php
@@ -19,6 +19,15 @@ interface RewriteColumnBehavior extends RewriteFilterBehavior
     public function rewriteColumn($column, ?string $relation = null);
 
     /**
+     * Get whether {@see rewriteColumn} might return an otherwise unknown column or expression
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isSelectableColumn(string $name): bool;
+
+    /**
      * Rewrite the given column definition
      *
      * @param ColumnDefinition $def

--- a/src/Contract/RewriteColumnBehavior.php
+++ b/src/Contract/RewriteColumnBehavior.php
@@ -2,6 +2,8 @@
 
 namespace ipl\Orm\Contract;
 
+use ipl\Orm\ColumnDefinition;
+
 interface RewriteColumnBehavior extends RewriteFilterBehavior
 {
     /**
@@ -15,4 +17,14 @@ interface RewriteColumnBehavior extends RewriteFilterBehavior
      * @return mixed
      */
     public function rewriteColumn($column, ?string $relation = null);
+
+    /**
+     * Rewrite the given column definition
+     *
+     * @param ColumnDefinition $def
+     * @param string $relation The absolute path of the model. For reference only, don't include it in the result
+     *
+     * @return void
+     */
+    public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void;
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -44,9 +44,9 @@ abstract class Model implements \ArrayAccess, \IteratorAggregate
     abstract public function getColumns();
 
     /**
-     * Get the model's column meta data
+     * Get the model's column definitions
      *
-     * Meta data is indexed by column names, values are either strings (labels) or arrays of this format:
+     * The array is indexed by column names, values are either strings (labels) or arrays of this format:
      *
      * [
      *  'label' => 'A Column',
@@ -55,7 +55,7 @@ abstract class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @return array
      */
-    public function getMetaData()
+    public function getColumnDefinitions()
     {
         return [];
     }

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -252,7 +252,7 @@ class Resolver
      *
      * @return array Column paths as keys (relative to $subject) and their meta data as values
      */
-    public function getMetaData(Model $subject)
+    public function getColumnDefinitions(Model $subject)
     {
         if (! $this->metaData->contains($subject)) {
             $this->metaData->attach($subject, $this->collectMetaData($subject));
@@ -292,7 +292,7 @@ class Resolver
             }
         } while ($parts);
 
-        $definition = $this->getMetaData($subject)[$column] ?? new ColumnDefinition($column);
+        $definition = $this->getColumnDefinitions($subject)[$column] ?? new ColumnDefinition($column);
         $this->getBehaviors($subject)->rewriteColumnDefinition($definition, implode('.', $relationPath));
 
         return $definition;

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -755,7 +755,7 @@ class Resolver
     protected function collectMetaData(Model $subject)
     {
         $definitions = [];
-        foreach ($subject->getMetaData() as $name => $data) {
+        foreach ($subject->getColumnDefinitions() as $name => $data) {
             if ($data instanceof ColumnDefinition) {
                 $definition = $data;
             } else {

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -206,8 +206,11 @@ class Resolver
         }
 
         $columns = $this->selectableColumns[$subject];
+        if (! isset($columns[$column])) {
+            $columns[$column] = $this->getBehaviors($subject)->isSelectableColumn($column);
+        }
 
-        return isset($columns[$column]);
+        return $columns[$column];
     }
 
     /**

--- a/tests/ApiIdentity.php
+++ b/tests/ApiIdentity.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Orm;
 
 use ipl\Orm\AliasedExpression;
 use ipl\Orm\Behaviors;
+use ipl\Orm\ColumnDefinition;
 use ipl\Orm\Contract\RewriteColumnBehavior;
 use ipl\Orm\Model;
 use ipl\Orm\Relations;
@@ -38,6 +39,15 @@ class ApiIdentity extends Model
                     $relation = str_replace('.', '_', $relation);
                     return new AliasedExpression("{$relation}_api_token", '"api_token retrieval not permitted"');
                 }
+            }
+
+            public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void
+            {
+            }
+
+            public function isSelectableColumn(string $name): bool
+            {
+                return $name === 'api_token';
             }
 
             public function rewriteCondition(Condition $condition, $relation = null)


### PR DESCRIPTION
Introduces a new class (`ColumnDefinition`) which purpose is to describe a column. Currently only a label can be provided. In the future we might extend this to provide datatypes and other useful information.

The interface `RewriteColumnBehavior` (introduced by #63) has also been extended by two new methods: `rewriteColumnDefinition` and `isSelectableColumn`
A behavior that is able to return *any* expression in `rewriteColumn` should be able to provide a definition and tell if it does provide such a column when being asked for it.

Method `getMetaData` of class `Model` has been renamed to `getColumnDefinitions`, to match the new type. Similarly `Resolver::getMetaData` is now `Resolver::getColumnDefinitions`, which also doesn't return any other definitions than those of the given model now. (Previously relations were inspected as well)
A new method `Resolver::getColumnDefinition` has been introduced as alternative. It takes a column path now and is not limited to :1 relations.

requires #63 