### PR TITLE
Fix ResultSet::next() to increment ResultSet::position when ResultSet::cache is valid

### DIFF
--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -81,6 +81,8 @@ class ResultSet implements Iterator
         if ($this->isCacheDisabled || ! $this->cache->valid()) {
             $this->generator->next();
             $this->advance();
+        } else {
+            $this->position += 1;
         }
     }
 

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -62,4 +62,23 @@ class ResultSetTest extends TestCase
             ['a', 'b', 'c', 'a', 'b', 'c']
         );
     }
+
+    public function testResultWithCacheEnabledWithLimit()
+    {
+        $set = (new ResultSet(new ArrayIterator(['a', 'b', 'c']), 2));
+
+        $items = [];
+        foreach ($set as $item) {
+            $items[] = $item;
+        }
+
+        foreach ($set as $item) {
+            $items[] = $item;
+        }
+
+        $this->assertEquals(
+            $items,
+            ['a', 'b', 'a', 'b']
+        );
+    }
 }


### PR DESCRIPTION
Earlier ResultSet::position was not incremented once the cache is filled and hence ResultSet::valid() was
not functioning as expected. Hence, Icinga\Module\Icingadb\Widget\ShowMore was not working as expected.

This fix resolves the issue.

fix Icinga/icingadb-web/issues/540