### PR TITLE
Binary behavior: Return non-resource as is

### DIFF
--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -27,19 +27,14 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
      */
     protected $rewriteSubjects;
 
-    /**
-     * @throws UnexpectedValueException If value is set and not a resource
-     */
     public function fromDb($value, $key, $_)
     {
         if ($value !== null) {
-            if (! is_resource($value)) {
-                throw new UnexpectedValueException(
-                    sprintf('%s should be a resource got %s instead', $key, get_php_type($value))
-                );
+            if (is_resource($value)) {
+                return stream_get_contents($value);
             }
 
-            return stream_get_contents($value);
+            return $value;
         }
 
         return null;


### PR DESCRIPTION
Otherwise the behavior throws an exception because it requires a
resource in fromDb(). This was created with the background that values
are only retrieved from the database via PDO. However, since behaviors
can be executed explicitly, any value can be passed from any source.
This must not fail if the value is not a resource. For example, we do
this in Icinga DB Web for values read from Redis.

fixes Icinga/ipl-orm#69