### PR TITLE
Introduce class `ipl\Orm\Behavior\NonTextMatch`

### DIFF
--- a/src/Behavior/NonTextMatch.php
+++ b/src/Behavior/NonTextMatch.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ipl\Orm\Behavior;
+
+use ipl\Orm\Contract\QueryAwareBehavior;
+use ipl\Orm\Contract\RewriteFilterBehavior;
+use ipl\Orm\Query;
+use ipl\Sql\Adapter\Pgsql;
+use ipl\Stdlib\Filter;
+
+class NonTextMatch implements RewriteFilterBehavior, QueryAwareBehavior
+{
+    /** @var Query */
+    protected $query;
+
+    public function setQuery(Query $query)
+    {
+        if ($query->getDb()->getAdapter() instanceof Pgsql) {
+            $this->query = $query;
+        }
+
+        return $this;
+    }
+
+    public function rewriteCondition(Filter\Condition $condition, $relation = null)
+    {
+        if ($this->query === null || (! $condition instanceof Filter\Like && ! $condition instanceof Filter\Unlike)) {
+            return null;
+        }
+
+        $columnDefinition = $this->query->getResolver()->getColumnDefinition($condition->metaData()->get('columnPath'));
+        if ($columnDefinition->getType() !== 'text') {
+            $condition->setColumn($condition->getColumn() . '::text');
+        }
+    }
+}


### PR DESCRIPTION
It's purpose is to automatically cast non-text values
to text if the used filter is a `LIKE`.

Though, I don't *like* this. But it's the only solution
right now. It depends highly on the maintained column
type. While this isn't that bad, since *I* believe there
are more text columns than other types (so maintaining them
isn't that difficult), but currentlyl there's no default
type. So if the type is not maintained, it currently casts
everything to text, even if not necessary. But is it a good
idea to have the type default to text?

This needs to be addressed.

Also, is there an alternative implementation? Another bad
thing is that each model has to provide it explicitly. This
should be a default behavior somehow if you ask me. If you
have several models seeing this everywhere makes you wonder:

```
$behaviors->add(new NonTextMatch());
```