### PR TITLE
Behaviors: Abort filter condition processing upon type change

### DIFF
--- a/src/Behaviors.php
+++ b/src/Behaviors.php
@@ -155,6 +155,10 @@ class Behaviors implements IteratorAggregate
             $replacement = $behavior->rewriteCondition($filter ?: $condition, $relation);
             if ($replacement !== null) {
                 $filter = $replacement;
+                if (! $filter instanceof Filter\Condition) {
+                    // Other behaviors get their chance once the replacement is being processed
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
This relies on the fact that the `FilterProcessor` re-evaluates
the behaviors for a changed filter. So any skipped behaviors
then get their chance to process the result.

fixes #45