### PR TITLE
FilterProcessor: Use cached iterator

### DIFF
--- a/src/Compat/FilterProcessor.php
+++ b/src/Compat/FilterProcessor.php
@@ -143,7 +143,16 @@ class FilterProcessor extends \ipl\Sql\Compat\FilterProcessor
 
             $subQueryGroups = [];
             $outsourcedRules = [];
-            foreach ($filter as $child) {
+
+            $iterator = $filter->getIterator(true);
+            for ($iterator->rewind(); $iterator->valid(); $iterator->next()) {
+                $child = $iterator->current();
+                if ($child instanceof Filter\Condition && ! $child->getChain()) {
+                    // Due to __clone() circular dependency (chain <-> rule) it's not sufficient to only set
+                    // the chain when adding the rule to that chain. Query class operates also on cloned filters
+                    $child->setChain($filter);
+                }
+
                 /** @var Filter\Rule $child */
                 $rewrittenFilter = $this->requireAndResolveFilterColumns($child, $query, $forceOptimization);
                 if ($rewrittenFilter !== null) {


### PR DESCRIPTION
At the moment, when iterating over a chain, a new iterator is constructed each time containing new rules. This prevents that rule/chain removed from somewhere else is also applied here, because it does not notice at all that something was removed.

### Requires

- https://github.com/Icinga/ipl-stdlib/pull/36