### PR TITLE
Resolver: De-duplicate base table columns

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -604,6 +604,7 @@ class Resolver
         $model = $model ?: $this->query->getModel();
         $tableName = $model->getTableAlias();
 
+        $baseTableColumns = [];
         foreach ($columns as $alias => $column) {
             $columnPath = &$column;
             if ($column instanceof ExpressionInterface) {
@@ -689,6 +690,16 @@ class Resolver
 
                     if (! $column instanceof ExpressionInterface) {
                         $column = $this->getBehaviors($target)->rewriteColumn($column) ?: $column;
+                    }
+
+                    if (is_int($alias) && ! $column instanceof AliasedExpression) {
+                        if (! isset($baseTableColumns[$columnPath])) {
+                            $baseTableColumns[$columnPath] = true;
+                        } else {
+                            // Don't yield base table columns multiple times.
+                            // Duplicate columns without an alias may lead to SQL errors
+                            continue 2;
+                        }
                     }
             }
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -327,4 +327,20 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('John Doe', $profile->test_user->username);
         $this->assertSame('secret', $profile->test_user->password);
     }
+
+    public function testWithColumnsDoesNotDuplicateBaseTableColumns()
+    {
+        $query = (new Query())
+            ->setModel(new User())
+            ->withColumns('user.username');
+
+        $this->assertSame(
+            [
+                'user.id',
+                'user.username',
+                'user.password'
+            ],
+            $query->assembleSelect()->getColumns()
+        );
+    }
 }


### PR DESCRIPTION
I've also played with `array_unique()` at first [here](https://github.com/Icinga/ipl-orm/blob/0b76de078b9ebff608ce07b1ea051fa7d82f6261/src/Query.php#L411). Though, didn't work as the array may contain non-strings (expressions).

Attempted also to remove [this](https://github.com/Icinga/ipl-orm/blob/0b76de078b9ebff608ce07b1ea051fa7d82f6261/src/Query.php#L423) to have base table columns aliased as well, which would have fixed the bug naturally. Though, this didn't work as well since we depend anywhere else upon the fact that base table columns have no alias...

fixes #79