### PR TITLE
Add BoolCast behavior

### DIFF
--- a/src/Behavior/BoolCast.php
+++ b/src/Behavior/BoolCast.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace ipl\Orm\Behavior;
+
+use InvalidArgumentException;
+use ipl\Orm\Contract\PropertyBehavior;
+
+use function ipl\Stdlib\get_php_type;
+
+/**
+ * Convert specific database values from and to boolean
+ *
+ * To unify the support of boolean values in different database systems,
+ * specific database values are converted to and from boolean values,
+ * e.g. by default `n` is converted to `false` and `y` to `true` and vice versa respectively,
+ * which could be stored as `ENUM('n', 'y')`.
+ */
+class BoolCast extends PropertyBehavior
+{
+    /** @var mixed Database value for boolean `false` */
+    protected $falseValue = 'n';
+
+    /** @var mixed Database value for boolean `true` */
+    protected $trueValue = 'y';
+
+    /** @var bool Whether to throw an exception if the value is not equal to the value for false or true */
+    protected $strict = true;
+
+    /**
+     * Get the database value representing boolean `false`
+     *
+     * @return mixed
+     */
+    public function getFalseValue()
+    {
+        return $this->falseValue;
+    }
+
+    /**
+     * Set the database value representing boolean `false`
+     *
+     * @param mixed $falseValue
+     *
+     * @return $this
+     */
+    public function setFalseValue($falseValue): self
+    {
+        $this->falseValue = $falseValue;
+
+        return $this;
+    }
+
+    /**
+     * Get the database value representing boolean `true`
+     *
+     * @return mixed
+     */
+    public function getTrueValue()
+    {
+        return $this->trueValue;
+    }
+
+    /**
+     * Get the database value representing boolean `true`
+     *
+     * @param mixed $trueValue
+     *
+     * @return $this
+     */
+    public function setTrueValue($trueValue): self
+    {
+        $this->trueValue = $trueValue;
+
+        return $this;
+    }
+
+    /**
+     * Get whether to throw an exception if the value is not equal to the value for false or true
+     *
+     * @return bool
+     */
+    public function isStrict(): bool
+    {
+        return $this->strict;
+    }
+
+    /**
+     * Set whether to throw an exception if the value is not equal to the value for false or true
+     *
+     * @param bool $strict
+     *
+     * @return $this
+     */
+    public function setStrict(bool $strict): self
+    {
+        $this->strict = $strict;
+
+        return $this;
+    }
+
+    public function fromDb($value, $key, $_)
+    {
+        switch (true) {
+            case $this->trueValue === $value:
+                return true;
+            case $this->falseValue === $value:
+                return false;
+            default:
+                if ($this->isStrict()) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Expected %s or %s, got %s instead',
+                        $this->trueValue,
+                        $this->falseValue,
+                        $value
+                    ));
+                }
+
+                return $value;
+        }
+    }
+
+    public function toDb($value, $key, $_)
+    {
+        if (! is_bool($value)) {
+            if ($this->isStrict()) {
+                throw new InvalidArgumentException(sprintf(
+                    'Expected bool, got %s instead',
+                    get_php_type($value)
+                ));
+            }
+
+            return $value;
+        }
+
+        return $value ? $this->trueValue : $this->falseValue;
+    }
+}

--- a/tests/Behavior/BoolCastTest.php
+++ b/tests/Behavior/BoolCastTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use InvalidArgumentException;
+use ipl\Orm\Behavior\BoolCast;
+
+class BoolCastTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSetFalseValue()
+    {
+        $this->assertSame('false', (new BoolCast([]))->setFalseValue('false')->getFalseValue());
+    }
+
+    public function testSetTrueValue()
+    {
+        $this->assertSame('true', (new BoolCast([]))->setTrueValue('true')->getTrueValue());
+    }
+
+    public function testSetStrict()
+    {
+        $behavior = new BoolCast([]);
+
+        $this->assertFalse($behavior->setStrict(false)->isStrict());
+        $this->assertTrue($behavior->setStrict(true)->isStrict());
+    }
+
+    public function testFromDbConvertsToBoolean()
+    {
+        $behavior = new BoolCast([]);
+
+        $this->assertFalse($behavior->fromDb($behavior->getFalseValue(), 'key', 'context'));
+        $this->assertTrue($behavior->fromDb($behavior->getTrueValue(), 'key', 'context'));
+    }
+
+    public function testToDbConvertsFromBoolean()
+    {
+        $behavior = new BoolCast([]);
+
+        $this->assertSame($behavior->getFalseValue(), $behavior->toDb(false, 'key', 'context'));
+        $this->assertSame($behavior->getTrueValue(), $behavior->toDb(true, 'key', 'context'));
+    }
+
+    public function testStrictIsDefault()
+    {
+        $this->assertTrue((new BoolCast([]))->isStrict());
+    }
+
+    public function testFromDbThrowsExceptionInStrictMode()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new BoolCast([]))->fromDb('strict', 'key', 'context');
+    }
+
+    public function testToDbThrowsExceptionInStrictMode()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new BoolCast([]))->toDb('strict', 'key', 'context');
+    }
+
+    public function testFromDbPassesNonMatchingValuesWithStrictModeDisabled()
+    {
+        $this->assertSame('pass', (new BoolCast([]))->setStrict(false)->fromDb('pass', 'key', 'context'));
+    }
+
+    public function testToDbPassesNonMatchingValuesWithStrictModeDisabled()
+    {
+        $this->assertSame('pass', (new BoolCast([]))->setStrict(false)->toDb('pass', 'key', 'context'));
+    }
+}


### PR DESCRIPTION
The BoolCast behavior is based on the behavior of Icinga DB Web, but implements a common usage:

- `y`/`n` are the default values for true and false, but can be overridden.
- The default mode is **strict**, meaning that if the value does not match the true or false value, an exception is thrown. However, this can be overridden so that a non-matching value is passed untouched.