### PR TITLE
Query: Fix order by expression causes fatal error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=7.2",
     "ext-pdo": "*",
-    "ipl/sql": ">=0.5.0",
+    "ipl/sql": ">=0.6.0",
     "ipl/stdlib": ">=0.12.0"
   },
   "autoload": {
@@ -25,7 +25,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "ipl\\Tests\\Orm\\": "tests"
+      "ipl\\Tests\\Orm\\": "tests",
+      "ipl\\Tests\\Sql\\": "vendor/ipl/sql/tests"
     }
   }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -235,6 +235,23 @@ class QueryTest extends TestCase
         );
     }
 
+    public function testQueryWithMultipleSortDirectionsInOrderBy()
+    {
+        $query = (new Query())
+            ->setModel(new User())
+            ->withColumns(['api_identity.api_token'])
+            ->orderBy('username', 'DESC')
+            ->orderBy('password', 'ASC')
+            ->orderBy('api_identity.api_token', 'DESC');
+
+        $orderBy = $query->assembleSelect()->getOrderBy();
+
+        $this->assertSame(
+            [['user.username', 'DESC'], ['user.password', 'ASC'], ['user_api_identity_api_token', 'DESC']],
+            $orderBy
+        );
+    }
+
     public function testQueryWithExpressionInOrderByThatUsesColumns()
     {
         $expression = new Expression("%s || ' ' || %s", ['username', 'profile.given_name']);

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Orm;
 
 use ipl\Orm\Exception\InvalidRelationException;
 use ipl\Orm\Query;
+use ipl\Sql\Expression;
 
 class QueryTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
### Before

When using something like this, a fatal PHP error occurs:

```php
$query->orderBy(new Expression('cnt DESC, certificate_issuer.subject')
```

```php
Uncaught TypeError: Illegal offset type in isset or empty in /usr/local/src/ipl-orm/src/Query.php:727
Stack trace:
#0 /usr/local/src/ipl-orm/src/Query.php(492): ipl\Orm\Query->order(Object(ipl\Sql\Select))
#1 /usr/local/src/ipl-orm/src/Query.php(641): ipl\Orm\Query->assembleSelect()
#2 /usr/local/src/ipl-orm/src/ResultSet.php(142): ipl\Orm\Query->yieldResults()
#3 [internal function]: ipl\Orm\ResultSet->yieldTraversable(Object(Generator))
#4 /usr/local/src/ipl-orm/src/ResultSet.php(122): Generator->valid()
#5 /usr/local/src/ipl-orm/src/ResultSet.php(114): ipl\Orm\ResultSet->advance()
#6 /usr/share/icingaweb2-modules/x509/library/X509/Donut.php(80): ipl\Orm\ResultSet->rewind()
...
```