### PR TITLE
Binary: Don't reset already hydrated data within the `setQuery()`

### DIFF
--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -25,7 +25,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
      *
      * @var array
      */
-    protected $rewriteSubjects;
+    protected $rewriteSubjects = [];
 
     public function fromDb($value, $key, $_)
     {
@@ -74,11 +74,9 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
 
     public function setQuery(Query $query)
     {
-        $this->rewriteSubjects = $this->properties;
-
-        if (! $query->getDb()->getAdapter() instanceof Pgsql) {
+        if ($query->getDb()->getAdapter() instanceof Pgsql) {
             // Only process properties if the adapter is PostgreSQL.
-            $this->properties = [];
+            $this->rewriteSubjects = $this->properties;
         }
     }
 


### PR DESCRIPTION
At the moment the behaviour isn't applied at all when using the mysql driver, because the model properties are simply being reset  when no pgsql adapter is used.