### PR TITLE
Make `Binary` behaviour extensible which might also be used for mysql adapter

### DIFF
--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -81,6 +81,8 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
             // Only process properties if the adapter is PostgreSQL.
             $this->properties = [];
         }
+
+        return $this;
     }
 
     public function rewriteCondition(Condition $condition, $relation = null)

--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -93,7 +93,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
         if (isset($this->rewriteSubjects[$column])) {
             $value = $condition->getValue();
 
-            if (empty($this->properties) && is_resource($value)) {
+            if (! empty($this->properties) && is_resource($value)) {
                 // Only for PostgreSQL.
                 throw new UnexpectedValueException(sprintf('Unexpected resource for %s', $column));
             }
@@ -105,11 +105,11 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
              * no further adjustments are needed as ctype_xdigit returns false for binary and bytea hex strings.
              */
             if (ctype_xdigit($value)) {
-                if (empty($this->properties) && substr($value, 0, 2) !== '\\x') {
-                    // Only for PostgreSQL.
-                    $condition->setValue(sprintf('\\x%s', $value));
-                } else {
+                if (empty($this->properties)) {
                     $condition->setValue(hex2bin($value));
+                } elseif (substr($value, 0, 2) !== '\\x') {
+                    // PostgreSQL.
+                    $condition->setValue(sprintf('\\x%s', $value));
                 }
             }
         }

--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -89,7 +89,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
          */
         $column = $condition->metaData()->get('columnName');
         if (isset($this->properties[$column])) {
-            $value = $condition->getValue();
+            $value = $condition->metaData()->get('originalValue');
 
             if ($this->isPostgres && is_resource($value)) {
                 throw new UnexpectedValueException(sprintf('Unexpected resource for %s', $column));

--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -18,18 +18,15 @@ use function ipl\Stdlib\get_php_type;
  */
 class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilterBehavior
 {
-    /**
-     * Properties for {@see rewriteCondition()} to support hex filters for each adapter
-     *
-     * Set in {@see setQuery()} from the {@see $properties} array because the latter is reset for adapters other than
-     * {@see Pgsql}, so {@see fromDb()} and {@see toDb()} don't run for them.
-     *
-     * @var array
-     */
-    protected $rewriteSubjects;
+    /** @var bool Whether the query is using a pgsql adapter */
+    protected $isPostgres = true;
 
     public function fromDb($value, $key, $_)
     {
+        if (! $this->isPostgres) {
+            return $value;
+        }
+
         if ($value !== null) {
             if (is_resource($value)) {
                 return stream_get_contents($value);
@@ -46,6 +43,10 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
      */
     public function toDb($value, $key, $_)
     {
+        if (! $this->isPostgres) {
+            return $value;
+        }
+
         if (is_resource($value)) {
             throw new ValueConversionException(sprintf('Unexpected resource for %s', $key));
         }
@@ -75,12 +76,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
 
     public function setQuery(Query $query)
     {
-        $this->rewriteSubjects = $this->properties;
-
-        if (! $query->getDb()->getAdapter() instanceof Pgsql) {
-            // Only process properties if the adapter is PostgreSQL.
-            $this->properties = [];
-        }
+        $this->isPostgres = $query->getDb()->getAdapter() instanceof Pgsql;
 
         return $this;
     }
@@ -92,11 +88,10 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
          * {@see \ipl\Orm\Compat\FilterProcessor::requireAndResolveFilterColumns()}
          */
         $column = $condition->metaData()->get('columnName');
-        if (isset($this->rewriteSubjects[$column])) {
+        if (isset($this->properties[$column])) {
             $value = $condition->getValue();
 
-            if (! empty($this->properties) && is_resource($value)) {
-                // Only for PostgreSQL.
+            if ($this->isPostgres && is_resource($value)) {
                 throw new UnexpectedValueException(sprintf('Unexpected resource for %s', $column));
             }
 
@@ -107,10 +102,9 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
              * no further adjustments are needed as ctype_xdigit returns false for binary and bytea hex strings.
              */
             if (ctype_xdigit($value)) {
-                if (empty($this->properties)) {
+                if (! $this->isPostgres) {
                     $condition->setValue(hex2bin($value));
                 } elseif (substr($value, 0, 2) !== '\\x') {
-                    // PostgreSQL.
                     $condition->setValue(sprintf('\\x%s', $value));
                 }
             }

--- a/src/Compat/FilterProcessor.php
+++ b/src/Compat/FilterProcessor.php
@@ -111,6 +111,8 @@ class FilterProcessor extends \ipl\Sql\Compat\FilterProcessor
                 }
 
                 $subjectBehaviors = $resolver->getBehaviors($subject);
+                // This is only used within the Binary behavior in rewriteCondition().
+                $filter->metaData()->set('originalValue', $filter->getValue());
 
                 try {
                     // Prepare filter as if it were final to allow full control for rewrite filter behaviors

--- a/tests/Behavior/BinaryTest.php
+++ b/tests/Behavior/BinaryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace ipl\Tests\Orm;
+
+use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Exception\ValueConversionException;
+use ipl\Orm\Query;
+use ipl\Sql\Connection;
+use ipl\Stdlib\Filter\Equal;
+use UnexpectedValueException;
+
+class BinaryTest extends \PHPUnit\Framework\TestCase
+{
+    protected const TEST_BINARY_VALUE = 'value';
+
+    protected const TEST_HEX_VALUE = '76616c7565';
+
+    protected const TEST_COLUMN = 'column';
+
+    public function testRetrievePropertyReturnsVanillaValueIfAdapterIsNotPostgreSQL(): void
+    {
+        $this->assertSame(
+            static::TEST_BINARY_VALUE,
+            $this->behavior()->retrieveProperty(static::TEST_BINARY_VALUE, static::TEST_COLUMN)
+        );
+    }
+
+    public function testRetrievePropertyReturnsStreamContentsIfAdapterIsPostgreSQL(): void
+    {
+        $stream = fopen('php://temp', 'r+');
+        fputs($stream, static::TEST_BINARY_VALUE);
+        rewind($stream);
+
+        $this->assertSame(
+            static::TEST_BINARY_VALUE,
+            $this->behavior(true)->retrieveProperty($stream, static::TEST_COLUMN)
+        );
+    }
+
+    public function testPersistPropertyReturnsVanillaValueIfAdapterIsNotPostgreSQL(): void
+    {
+        $this->assertSame(
+            static::TEST_BINARY_VALUE,
+            $this->behavior()->persistProperty(static::TEST_BINARY_VALUE, static::TEST_COLUMN)
+        );
+    }
+
+    public function testPersistPropertyReturnsByteaHexStringIfAdapterIsPostgreSQL(): void
+    {
+        $this->assertSame(
+            sprintf('\\x%s', static::TEST_HEX_VALUE),
+            $this->behavior(true)->persistProperty(static::TEST_BINARY_VALUE, static::TEST_COLUMN)
+        );
+    }
+
+    public function testRewriteConditionTransformsHexStringToBinaryIfAdapterIsNotPostgreSQL(): void
+    {
+        $c = $this->condition();
+
+        $this->behavior()->rewriteCondition($c);
+        $this->assertSame(static::TEST_BINARY_VALUE, $c->getValue());
+    }
+
+    public function testRewriteConditionTransformsHexStringToByteaHexStringIfAdapterIsPostgreSQL(): void
+    {
+        $c = $this->condition();
+
+        $this->behavior(true)->rewriteCondition($c);
+        $this->assertSame(
+            sprintf('\\x%s', static::TEST_HEX_VALUE),
+            $c->getValue()
+        );
+    }
+
+    /**
+     * We expect `retrieveProperty()` to return stream contents when the adapter is `PostgreSQL`.
+     * Working with streams in other functions is neither expected nor supported.
+     */
+    public function testPersistPropertyThrowsExceptionIfAdapterIsPostgreSQLAndValueIsResource(): void
+    {
+        $this->expectException(ValueConversionException::class);
+        $this->behavior(true)->persistProperty(fopen('php://temp', 'r'), static::TEST_COLUMN);
+    }
+
+    /**
+     * @see testPersistPropertyThrowsExceptionIfAdapterIsPostgreSQLAndValueIsResource()
+     */
+    public function testRewriteConditionThrowsExceptionIfAdapterIsPostgreSQLAndValueIsResource(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->behavior(true)->rewriteCondition($this->condition(fopen('php://temp', 'r')));
+    }
+
+    protected function behavior(bool $postgres = false): Binary
+    {
+        return (new Binary([static::TEST_COLUMN]))
+            ->setQuery(
+                (new Query())
+                    ->setDb($postgres ? new Connection(['db' => 'pgsql']) : new TestConnection())
+            );
+    }
+
+    protected function condition($value = self::TEST_HEX_VALUE): Equal
+    {
+        $c = new Equal(static::TEST_COLUMN, $value);
+        $c->metaData()->set('columnName', static::TEST_COLUMN);
+
+        return $c;
+    }
+}

--- a/tests/Behavior/BinaryTest.php
+++ b/tests/Behavior/BinaryTest.php
@@ -103,7 +103,9 @@ class BinaryTest extends \PHPUnit\Framework\TestCase
     protected function condition($value = self::TEST_HEX_VALUE): Equal
     {
         $c = new Equal(static::TEST_COLUMN, $value);
-        $c->metaData()->set('columnName', static::TEST_COLUMN);
+        $c->metaData()
+            ->set('originalValue', $value)
+            ->set('columnName', static::TEST_COLUMN);
 
         return $c;
     }


### PR DESCRIPTION
This now makes it possible to extend the `Binary` behaviour and to additionally apply other behaviours to the mysql adapter as well, such as the `IP` behaviour of the `x509` module.

fixes https://github.com/Icinga/icingaweb2-module-x509/issues/172