### PR TITLE
Do not apply behaviors twice

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/Behavior/Binary.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function substr expects string, mixed given\\.$#"
-			count: 1
-			path: src/Behavior/Binary.php
-
-		-
 			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Behavior/Binary.php

--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -59,18 +59,6 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
             return $value;
         }
 
-        /**
-         * TODO(lippserd): If the filter is moved to a subquery, the value has already been processed.
-         * This is because our filter processor is unfortunately doing the transformation twice at the moment:
-         *
-         * {@link https://github.com/Icinga/ipl-orm/issues/48}
-         *
-         * {@see \ipl\Orm\Compat\FilterProcessor::requireAndResolveFilterColumns()}
-         */
-        if (substr($value, 0, 2) === '\\x') {
-            return $value;
-        }
-
         return sprintf('\\x%s', bin2hex($value));
     }
 


### PR DESCRIPTION
This change prevents now the subject behaviors from being applied for the same filter condition over again when it's wrapped into a subquery. This PR removes also the (now obsolete if condition) from the binary behaviour.

fixes #48
closes https://github.com/Icinga/icingaweb2-module-x509/pull/174