### PR TITLE
PropertyBehavior: Check if a property exists before accessing it

### DIFF
--- a/src/Contract/PropertyBehavior.php
+++ b/src/Contract/PropertyBehavior.php
@@ -27,10 +27,8 @@ abstract class PropertyBehavior implements RetrieveBehavior, PersistBehavior
     public function retrieve(Model $model)
     {
         foreach ($this->properties as $key => $ctx) {
-            try {
+            if ($model->hasProperty($key)) {
                 $model[$key] = $this->fromDb($model[$key], $key, $ctx);
-            } catch (OutOfBoundsException $_) {
-                // pass
             }
         }
     }


### PR DESCRIPTION
`retrieve()` may be called hundreds if not even thousands of times. If for each call, even a small subset of properties doesn't exist, PHP will throw `OutOfBoundsException` for hundreds or thousands of times as well. Checking is way less expensive than throwing an error this often.

Speeds up queries with limited select lists and many model behaviors significantly.