### PR TITLE
SortUtil: Fix return type hint of `createOrderBy()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -101,11 +101,6 @@ parameters:
 			path: src/Common/SortUtil.php
 
 		-
-			message: "#^Method ipl\\\\Orm\\\\Common\\\\SortUtil\\:\\:createOrderBy\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Common/SortUtil.php
-
-		-
 			message: "#^Method ipl\\\\Orm\\\\Common\\\\SortUtil\\:\\:explodeSortSpec\\(\\) has parameter \\$sort with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Common/SortUtil.php
@@ -359,11 +354,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$properties of method ipl\\\\Orm\\\\Model\\:\\:setProperties\\(\\) expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Model.php
-
-		-
-			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/Query.php
 
 		-
 			message: "#^Cannot access an offset on mixed\\.$#"

--- a/src/Common/SortUtil.php
+++ b/src/Common/SortUtil.php
@@ -11,9 +11,9 @@ class SortUtil
      *
      * @param array|string $sort
      *
-     * @return array|null Sort column(s) and direction(s) suitable for {@link OrderByInterface::orderBy()}
+     * @return array<int, mixed> Sort column(s) and direction(s) suitable for {@link OrderByInterface::orderBy()}
      */
-    public static function createOrderBy($sort)
+    public static function createOrderBy($sort): array
     {
         $columnsAndDirections = static::explodeSortSpec($sort);
         $orderBy = [];


### PR DESCRIPTION
`createOrderBy()` can never return null.