### PR TITLE
Hydrator: Properly hydrate custom columns if an alias prefix is used

### DIFF
--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -151,6 +151,10 @@ class Hydrator
 
         // If there are any columns left, propagate them to the targeted relation if possible, to the base otherwise
         foreach ($data as $column => $value) {
+            if (($aliasPrefix = $this->query->getResolver()->getAliasPrefix())) {
+                $column = substr($column, strlen($aliasPrefix));
+            }
+
             $columnName = $column;
             $steps = explode('_', $column);
             $baseTable = array_shift($steps);

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -87,4 +87,25 @@ class HydratorTest extends TestCase
             'Custom aliases for relations are not correctly hydrated if their name contains an underscore'
         );
     }
+
+    public function testCustomColumnsAreProperlyHydratedIfAnAliasPrefixIsUsed()
+    {
+        $query = Car::on(new TestConnection());
+        $query->getResolver()->setAliasPrefix('test_');
+
+        $hydrator = $query->createHydrator();
+
+        $subject = new Car();
+        $hydrator->hydrate(['test_car_wheel_size' => 'xxl'], $subject);
+
+        $this->assertTrue(
+            isset($subject->wheel_size),
+            'Custom columns are not correctly hydrated if an alias prefix is in use'
+        );
+        $this->assertSame(
+            'xxl',
+            $subject->wheel_size,
+            'Custom columns are not correctly hydrated if an alias prefix is in use'
+        );
+    }
 }


### PR DESCRIPTION
fixes #127