### PR TITLE
Query: Determine omitted & target columns correctly

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -454,7 +454,18 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
         foreach ($resolved as $target) {
             $targetColumns = $resolved[$target]->getArrayCopy();
             if (isset($omitted[$target])) {
-                $targetColumns = array_diff($targetColumns, $omitted[$target]->getArrayCopy());
+                $toExclude = $omitted[$target]->getArrayCopy();
+                $targetColumns = array_filter($targetColumns, function ($column, $alias) use ($toExclude) {
+                    if (is_string($alias) && isset($toExclude[$alias])) {
+                        return false;
+                    }
+
+                    if (is_string($alias)) {
+                        return ! in_array($alias, $toExclude, true);
+                    }
+
+                    return ! in_array($column, $toExclude, true);
+                }, ARRAY_FILTER_USE_BOTH);
             }
 
             if (! empty($customAliases)) {


### PR DESCRIPTION
Excluding a column from a query/model that also contains expression columns fails as follows: I originally noticed this when working on https://github.com/Icinga/icingaweb2-module-nagvis/pull/61 where I wanted to exclude some columns from the `ServicestateSummary` model that were causing a PostgreSQL grouping error, but you can also easily trigger this in Icinga DB Web by adding `$servicegroupss->withoutColumns(‘id’);` in `ServicegroupsController` for example.

<img width="1237" alt="Bildschirmfoto 2024-09-20 um 09 46 32" src="https://github.com/user-attachments/assets/af020235-7404-4710-b754-e575f602868d">
