### PR TITLE
MillisecondTimestamp truncates values on 32 bit platforms

### DIFF
--- a/src/Behavior/MillisecondTimestamp.php
+++ b/src/Behavior/MillisecondTimestamp.php
@@ -25,7 +25,11 @@ class MillisecondTimestamp extends PropertyBehavior
     public function toDb($value, $key, $context)
     {
         if (is_numeric($value)) {
-            return (int) ($value * 1000.0);
+            if (PHP_INT_SIZE===4) {
+                return $value * 1000.0;
+            } else {
+                return (int) ($value * 1000.0);
+            }
         }
 
         if (! $value instanceof DateTime) {
@@ -36,6 +40,10 @@ class MillisecondTimestamp extends PropertyBehavior
             }
         }
 
-        return (int) ($value->format('U.u') * 1000.0);
+        if (PHP_INT_SIZE===4) {
+            return $value->format('U.u') * 1000.0;
+        } else {
+            return (int) ($value->format('U.u') * 1000.0);
+        }
     }
 }


### PR DESCRIPTION
fixes ipl-orm#143

A minimal check for 4 byte integers and when that is the case just leave the timestamp as a float. With that fixed the history screens shows the expected data.