### PR TITLE
Breaking changes in modernize code 

### DIFF
--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -66,7 +66,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
         return sprintf('\\x%s', bin2hex($value));
     }
 
-    public function setQuery(Query $query)
+    public function setQuery(Query $query): static
     {
         $this->isPostgres = $query->getDb()->getAdapter() instanceof Pgsql;
 

--- a/src/Behavior/Binary.php
+++ b/src/Behavior/Binary.php
@@ -9,6 +9,7 @@ use ipl\Orm\Exception\ValueConversionException;
 use ipl\Orm\Query;
 use ipl\Sql\Adapter\Pgsql;
 use ipl\Stdlib\Filter\Condition;
+use ipl\Stdlib\Filter\Rule;
 use UnexpectedValueException;
 
 use function ipl\Stdlib\get_php_type;
@@ -72,7 +73,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
         return $this;
     }
 
-    public function rewriteCondition(Condition $condition, $relation = null)
+    public function rewriteCondition(Condition $condition, ?string $relation = null): null
     {
         /**
          * TODO(lippserd): Duplicate code because {@see RewriteFilterBehavior}s come after {@see PropertyBehavior}s.
@@ -100,5 +101,7 @@ class Binary extends PropertyBehavior implements QueryAwareBehavior, RewriteFilt
                 }
             }
         }
+
+        return null;
     }
 }

--- a/src/Behavior/MillisecondTimestamp.php
+++ b/src/Behavior/MillisecondTimestamp.php
@@ -31,7 +31,7 @@ class MillisecondTimestamp extends PropertyBehavior
         if (! $value instanceof DateTime) {
             try {
                 $value = new DateTime($value);
-            } catch (Exception $err) {
+            } catch (Exception) {
                 throw new ValueConversionException(sprintf('Invalid date time format provided: %s', $value));
             }
         }

--- a/src/Contract/QueryAwareBehavior.php
+++ b/src/Contract/QueryAwareBehavior.php
@@ -14,5 +14,5 @@ interface QueryAwareBehavior extends Behavior
      *
      * @return $this
      */
-    public function setQuery(Query $query);
+    public function setQuery(Query $query): static;
 }

--- a/src/Contract/RewriteColumnBehavior.php
+++ b/src/Contract/RewriteColumnBehavior.php
@@ -16,7 +16,7 @@ interface RewriteColumnBehavior extends RewriteFilterBehavior
      *
      * @return mixed
      */
-    public function rewriteColumn($column, ?string $relation = null);
+    public function rewriteColumn(mixed $column, ?string $relation = null): mixed;
 
     /**
      * Get whether {@see rewriteColumn} might return an otherwise unknown column or expression

--- a/src/Contract/RewriteFilterBehavior.php
+++ b/src/Contract/RewriteFilterBehavior.php
@@ -17,9 +17,9 @@ interface RewriteFilterBehavior extends Behavior
      * Processing of the condition will be restarted, hence the column has to be an absolute path again.
      *
      * @param Filter\Condition $condition
-     * @param string           $relation The absolute path (with a trailing dot) of the model
+     * @param ?string          $relation The absolute path (with a trailing dot) of the model
      *
-     * @return Filter\Rule|null
+     * @return ?Filter\Rule
      */
-    public function rewriteCondition(Filter\Condition $condition, $relation = null);
+    public function rewriteCondition(Filter\Condition $condition, ?string $relation = null): ?Filter\Rule;
 }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -3,6 +3,7 @@
 namespace ipl\Orm;
 
 use ArrayIterator;
+use Generator;
 use Iterator;
 use Traversable;
 
@@ -33,7 +34,7 @@ class ResultSet implements Iterator
      *
      * @return static
      */
-    public static function fromQuery(Query $query)
+    public static function fromQuery(Query $query): static
     {
         return new static($query->yieldResults(), $query->getLimit());
     }
@@ -62,8 +63,7 @@ class ResultSet implements Iterator
         return $this->generator->valid();
     }
 
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         if ($this->position === null) {
             $this->advance();
@@ -134,7 +134,7 @@ class ResultSet implements Iterator
         }
     }
 
-    protected function yieldTraversable(Traversable $traversable)
+    protected function yieldTraversable(Traversable $traversable): Generator
     {
         foreach ($traversable as $key => $value) {
             yield $key => $value;

--- a/src/UnionModel.php
+++ b/src/UnionModel.php
@@ -13,7 +13,7 @@ abstract class UnionModel extends Model
      *
      * @return UnionQuery
      */
-    public static function on(Connection $db)
+    public static function on(Connection $db): UnionQuery
     {
         return (new UnionQuery())
             ->setDb($db)
@@ -25,5 +25,5 @@ abstract class UnionModel extends Model
      *
      * @return array
      */
-    abstract public function getUnions();
+    abstract public function getUnions(): array;
 }

--- a/tests/ApiIdentity.php
+++ b/tests/ApiIdentity.php
@@ -34,12 +34,14 @@ class ApiIdentity extends Model
     public function createBehaviors(Behaviors $behaviors)
     {
         $rewriteBehavior = new class () implements RewriteColumnBehavior {
-            public function rewriteColumn($column, $relation = null)
+            public function rewriteColumn(mixed $column, ?string $relation = null): ?AliasedExpression
             {
                 if ($column === 'api_token') {
                     $relation = str_replace('.', '_', $relation);
                     return new AliasedExpression("{$relation}_api_token", '"api_token retrieval not permitted"');
                 }
+
+                return null;
             }
 
             public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void

--- a/tests/ApiIdentity.php
+++ b/tests/ApiIdentity.php
@@ -9,6 +9,7 @@ use ipl\Orm\Contract\RewriteColumnBehavior;
 use ipl\Orm\Model;
 use ipl\Orm\Relations;
 use ipl\Stdlib\Filter\Condition;
+use ipl\Stdlib\Filter\Rule;
 
 class ApiIdentity extends Model
 {
@@ -50,8 +51,9 @@ class ApiIdentity extends Model
                 return $name === 'api_token';
             }
 
-            public function rewriteCondition(Condition $condition, $relation = null)
+            public function rewriteCondition(Condition $condition, ?string $relation = null): ?Rule
             {
+                return null;
             }
         };
 


### PR DESCRIPTION
Introduce breaking type additions that require compatibility changes in modules.

Requires changes to the following files:
icingadb-web:
*  [x] library/Icingadb/Model/ServicegroupSummary
* [x]  library/Icingadb/Model/Hostgroupsummary
* [x] library/Icingadb/Model/UnreachableParent/ResultSet
* [x] library/Icingadb/Redis/VolatileStateResults
* [x] library/Icingadb/Model/Behavior/FlattenedObjectVars
* [x] library/Icingadb/Model/Behavior/HasProblematicParent
* [x] library/Icingadb/Model/CustomvarFlat
* [x] library/Icingadb/Model/Behavior/Bitmask
* [x] library/Icingadb/Model/Behavior/Reroute

Nagvis:
* [x] library/Nagvis/Model/HostgroupSummary
* [x] library/Nagvis/Model/ServicegroupSummary

dependencies-web:
  requires no changes but  `library/Dependencies/Data/UnreachableParentResults` depends on the db-web changes

notifications-web:
* [x] library/Notifications/Model/Behavior/IdTagAggregator
* [x] library/Notifications/Model/Behavior/ObjectTags
* [x] library/Notifications/Model/Behavior/IcingaCustomVars

x509:
* [x] library/X509/Model/Behavior/ExpressionInjector

kubernetes-web:
* [x] library/Kubernetes/Model/Behavior/Uuid

partnerportal:
* [x] library/Partnerportal/Model/Behavior/AggregatedColumn.php

dependencies:
https://github.com/Icinga/icinga-notifications-web/pull/403
https://github.com/Icinga/icingadb-web/pull/1340
https://github.com/Icinga/icingaweb2-module-nagvis/pull/72
https://github.com/Icinga/icingaweb2-module-x509/pull/263
https://github.com/Icinga/icinga-kubernetes-web/pull/171
https://git.icinga.com/icingaweb2/icingaweb2-module-partnerportal/-/merge_requests/139