### PR TITLE
Repository housekeeping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Exclude Git and CI configuration files from archives.
+.git* export-ignore
+
+# Exclude test-related files from archives.
+tests/ export-ignore
+phpstan* export-ignore

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+      - support/*
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   php:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
-# Exclude all hidden files
-.*
-
-# Except those related to Git (and GitHub)
-!.git*
-
-# Exclude files from composer install
-vendor/
+# Ignore Composer installation artifacts; composer.lock is intentionally
+# excluded as this is a library - applications depending on this package
+# manage their own lock file.
+/vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "ipl/orm",
-  "type": "library",
   "description": "Icinga PHP Library - ORM",
   "license": "MIT",
+  "type": "library",
   "keywords": [
     "sql",
     "database",
@@ -15,19 +15,22 @@
     "ipl/sql": ">=0.9.1",
     "ipl/stdlib": ">=0.15.0"
   },
-  "autoload": {
-    "psr-4": {
-      "ipl\\Orm\\": "src"
-    }
-  },
   "require-dev": {
     "ext-pdo_sqlite": "*",
     "ipl/sql": "dev-main",
     "ipl/stdlib": "dev-main"
   },
+  "autoload": {
+    "psr-4": {
+      "ipl\\Orm\\": "src"
+    }
+  },
   "autoload-dev": {
     "psr-4": {
       "ipl\\Tests\\Orm\\": "tests"
     }
+  },
+  "config": {
+    "sort-packages": true
   }
 }


### PR DESCRIPTION
Apply a set of maintenance changes to normalize repository configuration:

- Extend CI to build on `support/*` branches, run for all PRs
  regardless of target, and allow manual dispatch
- Normalize `composer.json`
- Add `.gitattributes` to exclude CI and test files from `git archive`
- Tighten `.gitignore` to cover only Composer artifacts