### PR TITLE
Model: Accept passed properties in the constructor

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -16,7 +16,7 @@ abstract class Model implements \ArrayAccess, \IteratorAggregate
 
     final public function __construct(?array $properties = null)
     {
-        if ($this->hasProperties()) {
+        if (! empty($properties)) {
             $this->setProperties($properties);
         }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -2,6 +2,8 @@
 
 namespace ipl\Tests\Orm;
 
+use ipl\Orm\Model;
+
 class ModelTest extends \PHPUnit\Framework\TestCase
 {
     public function testInitIsCalledAfterConstruction()
@@ -20,5 +22,49 @@ class ModelTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($db, $query->getDb());
         /** @noinspection PhpParamsInspection */
         $this->assertInstanceOf(TestModel::class, $query->getModel());
+    }
+
+    public function testModelsCanBeInitializedWithProperties(): void
+    {
+        $model = new class (['foo' => 'bar']) extends Model {
+            public function getTableName()
+            {
+                return 'test';
+            }
+
+            public function getKeyName()
+            {
+                return 'id';
+            }
+
+            public function getColumns()
+            {
+                return ['foo'];
+            }
+        };
+
+        $this->assertSame('bar', $model->foo);
+    }
+
+    public function testModelsCanBeInitializedWithoutProperties(): void
+    {
+        $model = new class extends Model {
+            public function getTableName()
+            {
+                return 'test';
+            }
+
+            public function getKeyName()
+            {
+                return 'id';
+            }
+
+            public function getColumns()
+            {
+                return ['foo'];
+            }
+        };
+
+        $this->assertFalse(isset($model->foo));
     }
 }


### PR DESCRIPTION
This fixes a long standing oversight which wasn't even noticed when fixing access to a private property as it accessed `$this->properties` initially. This must have been a typo and the intendend check was to avoid passing an empty array and null to `setProperties`, as the constructor was always final and it is impossible the property can be non-empty at this stage. And even if so, why on earth would a base implementation only accept custom properties if it already has some…