### PR TITLE
Add generics to primary classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,26 +67,8 @@ parameters:
 			path: src/Behaviors.php
 
 		-
-			message: '#^Method ipl\\Orm\\Behaviors\:\:add\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Behaviors.php
-
-		-
 			message: '#^Method ipl\\Orm\\Behaviors\:\:getIterator\(\) return type with generic class ArrayIterator does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/Behaviors.php
-
-		-
-			message: '#^Method ipl\\Orm\\Behaviors\:\:persist\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Behaviors.php
-
-		-
-			message: '#^Method ipl\\Orm\\Behaviors\:\:retrieve\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Behaviors.php
 
@@ -139,30 +121,6 @@ parameters:
 			path: src/Common/SortUtil.php
 
 		-
-			message: '#^Method ipl\\Orm\\Compat\\FilterProcessor\:\:apply\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
-			message: '#^Method ipl\\Orm\\Compat\\FilterProcessor\:\:requireAndResolveFilterColumns\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
-			message: '#^Method ipl\\Orm\\Compat\\FilterProcessor\:\:requireAndResolveFilterColumns\(\) has parameter \$forceOptimization with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
-			message: '#^Parameter \#1 \$filter of method ipl\\Orm\\Query\:\:filter\(\) expects ipl\\Stdlib\\Filter\\Rule, ipl\\Stdlib\\Filter\\Chain\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
 			message: '#^Parameter \#1 \$path of method ipl\\Orm\\Resolver\:\:isDistinctRelation\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -187,44 +145,8 @@ parameters:
 			path: src/Compat/FilterProcessor.php
 
 		-
-			message: '#^Parameter \#2 \$value of static method ipl\\Stdlib\\Filter\:\:like\(\) expects array\<string\>\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
-			message: '#^Property ipl\\Orm\\Compat\\FilterProcessor\:\:\$baseJoins has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
-			message: '#^Property ipl\\Orm\\Compat\\FilterProcessor\:\:\$madeJoins has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Compat/FilterProcessor.php
-
-		-
-			message: '#^Method ipl\\Orm\\Contract\\PersistBehavior\:\:persist\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Contract/PersistBehavior.php
-
-		-
 			message: '#^Method ipl\\Orm\\Contract\\PropertyBehavior\:\:__construct\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Contract/PropertyBehavior.php
-
-		-
-			message: '#^Method ipl\\Orm\\Contract\\PropertyBehavior\:\:persist\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Contract/PropertyBehavior.php
-
-		-
-			message: '#^Method ipl\\Orm\\Contract\\PropertyBehavior\:\:retrieve\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Contract/PropertyBehavior.php
 
@@ -233,12 +155,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Contract/PropertyBehavior.php
-
-		-
-			message: '#^Method ipl\\Orm\\Contract\\RetrieveBehavior\:\:retrieve\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Contract/RetrieveBehavior.php
 
 		-
 			message: '#^Class ipl\\Orm\\Defaults implements generic interface IteratorAggregate but does not specify its types\: TKey, TValue$#'
@@ -257,12 +173,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Defaults.php
-
-		-
-			message: '#^Property ipl\\Orm\\Exception\\InvalidRelationException\:\:\$model \(ipl\\Orm\\Model\) does not accept ipl\\Orm\\Model\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Exception/InvalidRelationException.php
 
 		-
 			message: '#^Cannot call method getName\(\) on mixed\.$#'
@@ -355,18 +265,6 @@ parameters:
 			path: src/Model.php
 
 		-
-			message: '#^Method ipl\\Orm\\Model\:\:getProperty\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Model.php
-
-		-
-			message: '#^Method ipl\\Orm\\Model\:\:getProperty\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Model.php
-
-		-
 			message: '#^Method ipl\\Orm\\Model\:\:getSearchColumns\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -375,12 +273,6 @@ parameters:
 		-
 			message: '#^Method ipl\\Orm\\Model\:\:init\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Model.php
-
-		-
-			message: '#^Parameter \#1 \$properties of method ipl\\Orm\\Model\:\:setProperties\(\) expects array, array\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Model.php
 
@@ -415,12 +307,6 @@ parameters:
 			path: src/Query.php
 
 		-
-			message: '#^Class ipl\\Orm\\Query implements generic interface IteratorAggregate but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Query.php
-
-		-
 			message: '#^Method ipl\\Orm\\Query\:\:columns\(\) has parameter \$columns with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -429,12 +315,6 @@ parameters:
 		-
 			message: '#^Method ipl\\Orm\\Query\:\:dump\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Query.php
-
-		-
-			message: '#^Method ipl\\Orm\\Query\:\:first\(\) should return ipl\\Orm\\Model\|null but returns mixed\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Query.php
 
@@ -475,12 +355,6 @@ parameters:
 			path: src/Query.php
 
 		-
-			message: '#^Parameter \#1 \$objectOrClass of class ReflectionClass constructor expects class\-string\<T of object\>\|T of object, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Query.php
-
-		-
 			message: '#^Parameter \#1 \$subject of method ipl\\Orm\\Resolver\:\:getSelectColumns\(\) expects ipl\\Orm\\Model, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -501,12 +375,6 @@ parameters:
 		-
 			message: '#^Property ipl\\Orm\\Query\:\:\$columns type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Query.php
-
-		-
-			message: '#^Property ipl\\Orm\\Query\:\:\$count \(int\) does not accept int\|string\|false\|null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/Query.php
 
@@ -595,12 +463,6 @@ parameters:
 			path: src/Relation/BelongsToMany.php
 
 		-
-			message: '#^Method ipl\\Orm\\Relation\\BelongsToMany\:\:extractKey\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Relation/BelongsToMany.php
-
-		-
 			message: '#^Method ipl\\Orm\\Relation\\BelongsToMany\:\:extractKey\(\) has parameter \$possibleKey with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -615,12 +477,6 @@ parameters:
 		-
 			message: '#^Method ipl\\Orm\\Relation\\BelongsToMany\:\:getTargetForeignKey\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Relation/BelongsToMany.php
-
-		-
-			message: '#^Method ipl\\Orm\\Relation\\BelongsToMany\:\:getThrough\(\) should return ipl\\Orm\\Model but returns object\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Relation/BelongsToMany.php
 
@@ -649,26 +505,8 @@ parameters:
 			path: src/Relation/BelongsToMany.php
 
 		-
-			message: '#^Property ipl\\Orm\\Relation\\BelongsToMany\:\:\$through \(ipl\\Orm\\Model\) does not accept object\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Relation/BelongsToMany.php
-
-		-
 			message: '#^Class ipl\\Orm\\Relations implements generic interface IteratorAggregate but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/Relations.php
-
-		-
-			message: '#^Method ipl\\Orm\\Relations\:\:assertRelationDoesNotYetExist\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Relations.php
-
-		-
-			message: '#^Method ipl\\Orm\\Relations\:\:assertRelationExists\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Relations.php
 
@@ -699,12 +537,6 @@ parameters:
 		-
 			message: '#^Cannot call method isOne\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/Resolver.php
-
-		-
-			message: '#^Method ipl\\Orm\\Resolver\:\:collectColumns\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Resolver.php
 
@@ -863,78 +695,6 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: src/Resolver.php
-
-		-
-			message: '#^Class ipl\\Orm\\ResultSet implements generic interface Iterator but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:__construct\(\) has parameter \$limit with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:__construct\(\) has parameter \$traversable with no value type specified in iterable type Traversable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:advance\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:hasMore\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:hasResult\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:yieldTraversable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Method ipl\\Orm\\ResultSet\:\:yieldTraversable\(\) has parameter \$traversable with no value type specified in iterable type Traversable\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Property ipl\\Orm\\ResultSet\:\:\$cache has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Property ipl\\Orm\\ResultSet\:\:\$generator has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Property ipl\\Orm\\ResultSet\:\:\$limit has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/ResultSet.php
-
-		-
-			message: '#^Property ipl\\Orm\\ResultSet\:\:\$position has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/ResultSet.php
 
 		-
 			message: '#^Method ipl\\Orm\\UnionModel\:\:getUnions\(\) return type has no value type specified in iterable type array\.$#'

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -101,10 +101,12 @@ class Hydrator
     /**
      * Hydrate the given raw database rows into the specified model
      *
-     * @param array $data
-     * @param Model $model
+     * @template TModel of Model
      *
-     * @return Model
+     * @param array $data
+     * @param TModel $model
+     *
+     * @return TModel
      */
     public function hydrate(array $data, Model $model): Model
     {

--- a/src/Model.php
+++ b/src/Model.php
@@ -76,7 +76,7 @@ abstract class Model implements \ArrayAccess, \IteratorAggregate
      *
      * @param Connection $db
      *
-     * @return Query
+     * @return Query<static>
      */
     public static function on(Connection $db)
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -26,6 +26,9 @@ use Traversable;
 
 /**
  * Represents a database query which is associated to a model and a database connection.
+ *
+ * @template TRow of Model
+ * @implements IteratorAggregate<int, TRow>
  */
 class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Paginatable, IteratorAggregate
 {
@@ -53,10 +56,10 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /** @var Connection Database connection */
     protected $db;
 
-    /** @var string Class to return results as */
+    /** @var class-string<ResultSet<TRow>> Class to return results as */
     protected string $resultSetClass = ResultSet::class;
 
-    /** @var Model Model to query */
+    /** @var TRow Model to query */
     protected $model;
 
     /** @var array Columns to select from the model (or its relations). If empty, all columns are selected */
@@ -113,7 +116,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Get the class to return results as
      *
-     * @return string
+     * @return class-string<ResultSet<TRow>>
      */
     public function getResultSetClass(): string
     {
@@ -123,7 +126,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Set the class to return results as
      *
-     * @param string $class
+     * @param class-string<ResultSet<TRow>> $class
      *
      * @return $this
      *
@@ -145,7 +148,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Get the model to query
      *
-     * @return Model
+     * @return TRow
      */
     public function getModel()
     {
@@ -155,7 +158,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Set the model to query
      *
-     * @param Model $model
+     * @param TRow $model
      *
      * @return $this
      */
@@ -572,7 +575,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
      * Derive a new query to load the specified relation from a concrete model
      *
      * @param string $relation
-     * @param Model  $source
+     * @param TRow $source
      *
      * @return static
      *
@@ -593,7 +596,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
      *
      * @param Model $target The model to query
      * @param string $targetPath The target's absolute relation path
-     * @param ?Model $from The source model
+     * @param ?TRow $from The source model
      * @param bool $link Whether the query should be linked to the parent query
      *
      * @return static
@@ -658,12 +661,11 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Execute the query
      *
-     * @return ResultSet
+     * @return ResultSet<TRow>
      */
     public function execute(): ResultSet
     {
         $class = $this->getResultSetClass();
-        /** @var ResultSet $class Just for type hinting. $class is of course a string */
 
         return $class::fromQuery($this);
     }
@@ -671,7 +673,7 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Fetch and return the first result
      *
-     * @return Model|null Null in case there's no result
+     * @return ?TRow Null in case there's no result
      */
     public function first(): ?Model
     {
@@ -698,7 +700,8 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
     /**
      * Yield the query's results
      *
-     * @return Generator
+     * @return Generator<mixed, int, TRow, void>
+     * @phpstan-return Generator<int, TRow, mixed, void>
      */
     public function yieldResults(): Generator
     {
@@ -723,6 +726,11 @@ class Query implements Filterable, LimitOffsetInterface, OrderByInterface, Pagin
         return $this->count;
     }
 
+    /**
+     * Get the query's result set
+     *
+     * @return Traversable<int, TRow>
+     */
     public function getIterator(): Traversable
     {
         return $this->execute();

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -7,19 +7,34 @@ use Generator;
 use Iterator;
 use Traversable;
 
+/**
+ * @template TRow of Model
+ * @implements Iterator<int, TRow>
+ */
 class ResultSet implements Iterator
 {
+    /** @var ArrayIterator<int, TRow> */
     protected ArrayIterator $cache;
 
     /** @var bool Whether cache is disabled */
     protected bool $isCacheDisabled = false;
 
+    /**
+     * @var Generator<mixed, int, TRow, void>
+     * @phpstan-var Generator<int, TRow, mixed, void>
+     */
     protected Generator $generator;
 
     protected ?int $limit;
 
     protected ?int $position = null;
 
+    /**
+     * Create a new result set from the given traversable
+     *
+     * @param Traversable<int, TRow> $traversable
+     * @param ?int $limit
+     */
     public function __construct(Traversable $traversable, ?int $limit = null)
     {
         $this->cache = new ArrayIterator();
@@ -30,9 +45,10 @@ class ResultSet implements Iterator
     /**
      * Create a new result set from the given query
      *
-     * @param Query $query
+     * @template TQueryRow of Model
+     * @param Query<TQueryRow> $query
      *
-     * @return static
+     * @return static<TQueryRow>
      */
     public static function fromQuery(Query $query)
     {
@@ -63,6 +79,7 @@ class ResultSet implements Iterator
         return $this->generator->valid();
     }
 
+    /** @return TRow */
     #[\ReturnTypeWillChange]
     public function current()
     {
@@ -135,6 +152,14 @@ class ResultSet implements Iterator
         }
     }
 
+    /**
+     * Yield the given traversable
+     *
+     * @param Traversable<int, TRow> $traversable
+     *
+     * @return Generator<mixed, int, TRow, void>
+     * @phpstan-return Generator<int, TRow, mixed, void>
+     */
     protected function yieldTraversable(Traversable $traversable)
     {
         foreach ($traversable as $key => $value) {


### PR DESCRIPTION
Query instances, such as those for eagerly loaded relations can now use `Query<$TargetClass>` to get better code inspection hints in PHPStorm when code accesses said properties.

The partial application is deliberate to jump-start it and get a feel for it in projects using the ORM.