### PR TITLE
Fix that `MillisecondTimestamp` converts null to int

### DIFF
--- a/src/Behavior/MillisecondTimestamp.php
+++ b/src/Behavior/MillisecondTimestamp.php
@@ -24,6 +24,10 @@ class MillisecondTimestamp extends PropertyBehavior
 
     public function toDb($value, $key, $context)
     {
+        if ($value === null) {
+            return null;
+        }
+
         if (is_numeric($value)) {
             return (int) ($value * 1000.0);
         }

--- a/tests/MillisecondTimestampBehaviorTest.php
+++ b/tests/MillisecondTimestampBehaviorTest.php
@@ -15,6 +15,11 @@ class MillisecondTimestampBehaviorTest extends TestCase
         $this->assertNull((new MillisecondTimestamp([]))->fromDb(null, 'key', null));
     }
 
+    public function testToDbReturnsNullWhenNullIsPassed()
+    {
+        $this->assertNull((new MillisecondTimestamp([]))->toDb(null, 'key', null));
+    }
+
     public function testToDbReturnsUtcTimestampWithNonUtcInput()
     {
         $sometime = DateTime::createFromFormat(


### PR DESCRIPTION
In case of nullable columns, this fix is required.